### PR TITLE
Fixing a typo in documentation for MazarsModel

### DIFF
--- a/doc/matlibmanual/matlibmanual.tex
+++ b/doc/matlibmanual/matlibmanual.tex
@@ -2566,7 +2566,7 @@ $g_t= 1.0-(1.0-A_t)*\varepsilon_0/\kappa - A_t*\exp(-B_t*(\kappa-\varepsilon_0))
 $ of
 tension damage evolution law is used, if equal 1, the modified law
 used which asymptotically tends to zero
-$g_t = 1.0-(\varepsilon_0/\kappa)*\exp((\varepsilon_0-\kappa)/A_t)$\\
+$g_t = 1.0-(\varepsilon_0/\kappa)*\exp((\varepsilon_0-\kappa)/\varepsilon_f)$\\
 &- \param{tAlpha} thermal dilatation coefficient\\
 &- \param{equivstraintype} see Tab.~\ref{id_table}\\
 &- \param{maxOmega} limit maximum damage, use for convergency improvement\\


### PR DESCRIPTION
There is a typo in the expression for the modified damage evolution law in version 1 of MazarsModel.