### PR TITLE
Plane stress support in StructuralFE2Material

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,7 +90,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 RawStringFormats: 
-  - Delimiter:       pb
+  - Delimiters:       [pb]
     Language:        TextProto
     BasedOnStyle:    google
 ReflowComments:  true

--- a/src/oofemlib/prescribedgradienthomogenization.C
+++ b/src/oofemlib/prescribedgradienthomogenization.C
@@ -67,7 +67,7 @@ void PrescribedGradientHomogenization :: setPrescribedGradientVoigt(const FloatA
         this->mGradient.at(2, 2) = t.at(2);
         // In voigt form, assuming the use of gamma_12 instead of eps_12
         this->mGradient.at(1, 2) = this->mGradient.at(2, 1) = t.at(3) * 0.5;
-    } if ( n == 4 ) { // Then 2D
+    } else if ( n == 4 ) { // Then 2D
         this->mGradient.resize(2, 2);
         this->mGradient.at(1, 1) = t.at(1);
         this->mGradient.at(2, 2) = t.at(2);

--- a/src/sm/Elements/Beams/libeam3dboundaryvoigt.C
+++ b/src/sm/Elements/Beams/libeam3dboundaryvoigt.C
@@ -63,7 +63,11 @@ LIBeam3dBoundaryVoigt :: initializeFrom(InputRecord &ir)
 void
 LIBeam3dBoundaryVoigt :: giveDofManDofIDMask(int inode, IntArray &answer) const
 {
-    answer = { D_u, D_v, D_w, R_u, R_v, R_w };
+    if ( inode == 3 ) {
+        answer = { E_xx, E_yy, E_zz, G_yz, G_xz, G_xy };
+    } else {
+        answer = { D_u, D_v, D_w, R_u, R_v, R_w };
+    }
 }
 
 

--- a/src/sm/Elements/Beams/libeam3dboundaryvoigt.h
+++ b/src/sm/Elements/Beams/libeam3dboundaryvoigt.h
@@ -46,7 +46,7 @@ namespace oofem {
 /**
  * This class implements a boundary version of the 3-dimensional mindlin theory Linear Isoparametric
  * beam element, with reduced integration. Useful for prescribing periodicity in multiscale analyses.
- * MACROSCOPIC INPUT: STRAIN TENSOR (3D, 6 COMPONENTS, VOIGT NOTATION: exx eyy ezz gyz gxz gxy)
+ * MACROSCOPIC INPUT: STRAIN TENSOR (3D, 6 COMPONENTS, VOIGT NOTATION: Exx Eyy Ezz Gyz Gxz Gxy)
  *
  * @author: Adam Sciegaj
  */

--- a/src/sm/Materials/structuralfe2material.h
+++ b/src/sm/Materials/structuralfe2material.h
@@ -135,8 +135,10 @@ public:
 
     MaterialStatus *CreateStatus(GaussPoint *gp) const override;
     FloatArrayF<6> giveRealStressVector_3d(const FloatArrayF<6> &strain, GaussPoint *gp, TimeStep *tStep) const override;
+    FloatArrayF<3> giveRealStressVector_PlaneStress(const FloatArrayF< 3 > &strain, GaussPoint *gp, TimeStep *tStep) const override;
     FloatMatrixF<6,6> give3dMaterialStiffnessMatrix(MatResponseMode mode, GaussPoint *gp, TimeStep *tStep) const override;
     FloatMatrixF<4,4> givePlaneStrainStiffMtrx(MatResponseMode mode, GaussPoint *gp, TimeStep *tStep) const override;
+    FloatMatrixF<3,3> givePlaneStressStiffMtrx(MatResponseMode mmode, GaussPoint *gp, TimeStep *tStep) const override;
 };
 
 } // end namespace oofem

--- a/tests/sm/fe2structuralmaterial2.in
+++ b/tests/sm/fe2structuralmaterial2.in
@@ -1,0 +1,44 @@
+test.out
+Test for multiscale modeling using fe2structuralmaterial - plane stress.
+StaticStructural nsteps 1 nmodules 1
+#vtkxml tstep_all domain_all primvars 1 1 cellvars 1 1
+errorcheck
+domain 2dplanestress
+OutputManager tstep_all dofman_all element_all
+ndofman 12 nelem 5 ncrosssect 1 nmat 1 nbc 2 nic 0 nltf 1 nset 3 nxfemman 0
+node 1     coords 3  0        0        0
+node 2     coords 3  1        0        0
+node 3     coords 3  1        0.2      0
+node 4     coords 3  0        0.2      0
+node 5     coords 3  0.2      0        0
+node 6     coords 3  0.4      0        0
+node 7     coords 3  0.6      0        0
+node 8     coords 3  0.8      0        0
+node 9     coords 3  0.8      0.2      0
+node 10    coords 3  0.6      0.2      0
+node 11    coords 3  0.4      0.2      0
+node 12    coords 3  0.2      0.2      0
+planestress2d 13    nodes 4   1   5   12  4
+planestress2d 14    nodes 4   5   6   11  12
+planestress2d 15    nodes 4   6   7   10  11
+planestress2d 16    nodes 4   7   8   9   10
+planestress2d 17    nodes 4   8   2   3   9
+Set 1 elementranges {(13 17)}
+Set 2 nodes 2 1 4
+Set 3 nodes 2 2 3
+#
+SimpleCS 1 thick 1.0 material 1 set 1
+# Linear elasticity
+structfe2material 1 d 1.0 filename fe2structuralmaterial2.in.rve use_num_tangent
+#
+BoundaryCondition 1 loadTimeFunction 1 dofs 2 1 2 values 2 0 0 set 2
+NodalLoad 2 loadTimeFunction 1 dofs 2 1 2 components 2 0.0 -0.5e6 set 3
+ConstantFunction 1 f(t) 1.0
+#
+#%BEGIN_CHECK% tolerance 1.e-4
+## check selected nodes
+#NODE tStep 1 number 2 dof 1 unknown d value -3.25000000e-04
+#NODE tStep 1 number 2 dof 2 unknown d value -2.20690476e-03
+##
+#%END_CHECK%
+

--- a/tests/sm/fe2structuralmaterial2.in.rve
+++ b/tests/sm/fe2structuralmaterial2.in.rve
@@ -1,0 +1,20 @@
+rvesmall.out
+Small RVE for automatic test.
+StaticStructural nsteps 1 deltat 1.0 rtolv 1.0e-6 MaxIter 40 minIter 2 nmodules 0 manrmsteps 1
+#vtkxml tstep_all domain_all primvars 1 1 cellvars 1 1
+domain 2dplanestress
+OutputManager
+ndofman 4 nelem 1 ncrosssect 1 nmat 1 nbc 1 nic 0 nltf 1 nset 1 nxfemman 0
+node 1     coords 3  0        0        0       
+node 2     coords 3  0.01     0        0       
+node 3     coords 3  0.01     0.01     0       
+node 4     coords 3  0        0.01     0       
+planestress2d 1    nodes 4   1   2  3  4  crosssect 1
+SimpleCS 1 thick 1.0 material 1
+#
+#Linear elasticity
+IsoLE 1 d 1.0 E 210.0e9 n 0.3 tAlpha 0.0
+PrescribedGradient 1 dofs 2 1 2 set 1 loadTimeFunction 1 ccoord 3 0.0 0.0 0.0 gradient 3 3 {1.0 0.0 0.0; 0.0 0.0 0.0; 0.0 0.0 0.0}
+#
+ConstantFunction 1 f(t) 1.0
+set 1 elementboundaries 8 1 1 1 2 1 3 1 4 


### PR DESCRIPTION
- Added support for plane stress problems using StructuralFE2Material along with a test case (based on fe2structuralmaterial1 test).
- Changed the old incorrect DofIDItem for one of LIBeam3dBoundary elements
- Updated clang-format to work with CLion IDE 