### PR TITLE
Changing edge normals to outward-pointing for 2d/line elements

### DIFF
--- a/src/oofemlib/fei2dlinehermite.C
+++ b/src/oofemlib/fei2dlinehermite.C
@@ -128,8 +128,8 @@ void FEI2dLineHermite :: edgeEvald2Nds2(FloatArray &answer, int iedge, const Flo
 double FEI2dLineHermite :: edgeEvalNormal(FloatArray &normal, int iedge, const FloatArray &lcoords, const FEICellGeometry &cellgeo)
 {
     normal.resize(2);
-    normal.at(1) = cellgeo.giveVertexCoordinates(2).at(xind) - cellgeo.giveVertexCoordinates(1).at(xind);
-    normal.at(2) = -( cellgeo.giveVertexCoordinates(2).at(yind) - cellgeo.giveVertexCoordinates(1).at(yind) );
+    normal.at(1) = cellgeo.giveVertexCoordinates(2).at(yind) - cellgeo.giveVertexCoordinates(1).at(yind);
+    normal.at(2) = -( cellgeo.giveVertexCoordinates(2).at(xind) - cellgeo.giveVertexCoordinates(1).at(xind) );
 
     return normal.normalize() * 0.5;
 }

--- a/src/oofemlib/fei2dlinequad.C
+++ b/src/oofemlib/fei2dlinequad.C
@@ -168,6 +168,7 @@ void FEI2dLineQuad :: edgeEvaldNds(FloatArray &answer, int iedge,
 
 double FEI2dLineQuad :: edgeEvalNormal(FloatArray &normal, int iedge, const FloatArray &lcoords, const FEICellGeometry &cellgeo)
 {
+    const auto &edgeNodes = this->computeLocalEdgeMapping(iedge);
     double xi = lcoords(0);
     double dN1dxi = -0.5 + xi;
     double dN2dxi =  0.5 + xi;
@@ -175,13 +176,13 @@ double FEI2dLineQuad :: edgeEvalNormal(FloatArray &normal, int iedge, const Floa
 
     normal.resize(2);
 
-    normal.at(1) = - dN1dxi *cellgeo.giveVertexCoordinates(1).at(yind) +
-                   - dN2dxi *cellgeo.giveVertexCoordinates(2).at(yind) +
-                   - dN3dxi *cellgeo.giveVertexCoordinates(3).at(yind);
+    normal.at(1) = dN1dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(1) ).at(yind) +
+                   dN2dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(2) ).at(yind) +
+                   dN3dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(3) ).at(yind);
 
-    normal.at(2) = dN1dxi * cellgeo.giveVertexCoordinates(1).at(xind) +
-                   dN2dxi *cellgeo.giveVertexCoordinates(2).at(xind) +
-                   dN3dxi *cellgeo.giveVertexCoordinates(3).at(xind);
+    normal.at(2) = - dN1dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(1) ).at(xind) +
+                   - dN2dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(2) ).at(xind) +
+                   - dN3dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(3) ).at(xind);
 
     return normal.normalize();
 }

--- a/src/oofemlib/fei2dquadlin.C
+++ b/src/oofemlib/fei2dquadlin.C
@@ -267,8 +267,8 @@ FEI2dQuadLin :: edgeEvalNormal(FloatArray &answer, int iedge, const FloatArray &
     int nodeB = edgeNodes.at(2);
 
     answer = {
-        cellgeo.giveVertexCoordinates(nodeA).at(yind) - cellgeo.giveVertexCoordinates(nodeB).at(yind),
-        cellgeo.giveVertexCoordinates(nodeB).at(xind) - cellgeo.giveVertexCoordinates(nodeA).at(xind)
+        cellgeo.giveVertexCoordinates(nodeB).at(yind) - cellgeo.giveVertexCoordinates(nodeA).at(yind),
+        cellgeo.giveVertexCoordinates(nodeA).at(xind) - cellgeo.giveVertexCoordinates(nodeB).at(xind)
     };
     return answer.normalize() * 0.5;
 }

--- a/tests/sm/patch106.in
+++ b/tests/sm/patch106.in
@@ -22,7 +22,7 @@ SimpleCS 1 thick 0.15 material 1 set 1
 IsoLE 1 d 0. E 15.0 n 0.25 tAlpha 0.000012
 BoundaryCondition 1 loadTimeFunction 1 dofs 1 2 values 1 0 set 1
 BoundaryCondition 2 loadTimeFunction 1 dofs 1 1 values 1 0 set 2
-ConstantEdgeLoad 3 loadTimeFunction 1 dofs 2 1 2 Components 2 0.0 1.25 loadType 3 csType 1 set 0
+ConstantEdgeLoad 3 loadTimeFunction 1 dofs 2 1 2 Components 2 0.0 -1.25 loadType 3 csType 1 set 0
 ConstantFunction 1 f(t) 1.0
 Set 1 elementranges {(1 5)}
 Set 2 nodes 2 1 2


### PR DESCRIPTION
This pull request unifies the normal vectors given by edgeEvalNormal methods to be outward-pointing for 2d elements with anti-clockwise node numbering (as specified by OOFEM Element Library Manual).  The same convention is used for line elements, i.e., the line element is treated as if it was an edge of a 2d element (node numbering determines which edge).