### PR TITLE
rewrote treatment of return results in cdpm2 and lattice material models

### DIFF
--- a/src/sm/Materials/ConcreteMaterials/concretedpm2.h
+++ b/src/sm/Materials/ConcreteMaterials/concretedpm2.h
@@ -98,17 +98,6 @@ public:
         ConcreteDPM2_VertexTensionDamage
     };
 
-    enum ConcreteDPM2_ReturnType {
-        RT_Regular,
-        RT_Tension,
-        RT_Compression,
-        RT_Auxiliary
-    };
-
-    enum ConcreteDPM2_ReturnResult {
-        RR_NotConverged,
-        RR_Converged
-    };
 
 
 protected:
@@ -185,12 +174,6 @@ protected:
     /// Indicates the state (i.e. elastic, unloading, plastic, damage, vertex) of the Gauss point
     int state_flag = ConcreteDPM2Status::ConcreteDPM2_Elastic;
     int temp_state_flag = ConcreteDPM2Status::ConcreteDPM2_Elastic;
-
-    int returnType = ConcreteDPM2Status::RT_Regular;
-    int tempReturnType = ConcreteDPM2Status::RT_Regular;
-
-    int returnResult = ConcreteDPM2Status::RR_NotConverged;
-    int tempReturnResult = ConcreteDPM2Status::RR_NotConverged;
 
 
 #ifdef keep_track_of_dissipated_energy
@@ -471,9 +454,6 @@ public:
     int giveTempStateFlag() const
     { return temp_state_flag; }
 
-    int giveTempReturnType() const { return tempReturnType; }
-    int giveTempReturnResult() const { return tempReturnResult; }
-
     // letTemp...be :
     // Functions used by the material to assign a new value to a temp variable.
     /**
@@ -603,10 +583,6 @@ public:
     void letTempStateFlagBe(const int v)
     { temp_state_flag = v; }
 
-    void letTempReturnTypeBe(const int type) { tempReturnType = type; }
-
-    void letTempReturnResultBe(const int result) { tempReturnResult = result; }
-
     void letKappaPPeakBe(double kappa)
     { kappaPPeak = kappa; }
 #ifdef keep_track_of_dissipated_energy
@@ -651,6 +627,21 @@ public:
 class ConcreteDPM2 : public StructuralMaterial
 {
 public:
+
+    enum ConcreteDPM2_ReturnResult {
+        RR_Unknown,
+        RR_NotConverged,
+        RR_Converged
+    };
+
+    enum ConcreteDPM2_ReturnType {
+        RT_Unknown,
+        RT_Regular,
+        RT_Tension,
+        RT_Compression,
+        RT_Auxiliary
+    };
+
 
 protected:
     /// Parameters of the yield surface of the plasticity model. fc is the uniaxial compressive strength, ft the uniaxial tensile strength and ecc controls the out of roundness of the deviatoric section.
@@ -782,6 +773,7 @@ public:
      * @param gp Gauss point
      */
     void checkForVertexCase(double &answer,
+                            ConcreteDPM2_ReturnType &returnType,
                             double sig,
                             double tempKappa,
                             GaussPoint *gp) const;
@@ -794,6 +786,8 @@ public:
      * @param theta Load angle of trial stress (remains constant throughout return).
      */
     double performRegularReturn(FloatArrayF< 6 > &stress,
+                                ConcreteDPM2_ReturnResult &returnResult,
+                                ConcreteDPM2_ReturnType &returnType,
                                 double kappaP,
                                 GaussPoint *gp,
                                 double theta) const;
@@ -823,6 +817,8 @@ public:
      * @returns updated temporary cummulative plastic strain
      */
     double performVertexReturn(FloatArrayF< 6 > &stress,
+                               ConcreteDPM2_ReturnResult &returnResult,
+                               ConcreteDPM2_ReturnType &returnType,
                                double apexStress,
                                double tempKappaP,
                                GaussPoint *gp) const;
@@ -1126,6 +1122,7 @@ public:
 
     void saveContext(DataStream &stream, ContextMode mode) override;
     void restoreContext(DataStream &stream, ContextMode mode) override;
+
 
 protected:
     MaterialStatus *CreateStatus(GaussPoint *gp) const override;

--- a/src/sm/Materials/LatticeMaterials/latticebondplasticity.h
+++ b/src/sm/Materials/LatticeMaterials/latticebondplasticity.h
@@ -103,11 +103,9 @@ class LatticeBondPlasticity : public LatticeLinearElastic
 {
 protected:
 
-    enum LatticeBondPlasticity_SurfaceType { ST_Vertex, ST_Shear, ST_Compression };
-    mutable LatticeBondPlasticity_SurfaceType surfaceType; // FIXME: Must be removed. Not thread safe. Shouldn't be stored at all.
+    enum LatticeBondPlasticity_SurfaceType { ST_Unknown, ST_Vertex, ST_Shear, ST_Compression };
 
     enum LatticeBondPlasticity_ReturnResult { RR_NotConverged, RR_Converged, RR_Elastic };
-    mutable LatticeBondPlasticity_ReturnResult returnResult; // FIXME: Must be removed. Not thread safe. Shouldn't be stored at all.
 
     int giveIPValue(FloatArray &answer, GaussPoint *gp, InternalStateType type, TimeStep *atTime) override;
 
@@ -199,6 +197,8 @@ public:
     FloatArrayF< 3 >performPlasticityReturn(GaussPoint *gp, const FloatArrayF< 3 > &totalStrain, TimeStep *) const;
 
     double performRegularReturn(FloatArrayF< 3 > &stress,
+                                LatticeBondPlasticity_ReturnResult &returnResult,
+                                LatticeBondPlasticity_SurfaceType &surfaceType,
                                 double yieldValue,
                                 int transitionFlag,
                                 GaussPoint *gp) const;

--- a/src/sm/Materials/LatticeMaterials/latticeplasticitydamage.C
+++ b/src/sm/Materials/LatticeMaterials/latticeplasticitydamage.C
@@ -286,11 +286,11 @@ LatticePlasticityDamage::computeMVector(const FloatArrayF< 3 > &stress,
     if ( stress.at(1) >= transition ) { //ellipse
         m.at(1) = 2. * pow(this->flowAngleOne, 2.) * stress.at(1) + 2. * ( fcLocal - this->flowAngleOne * this->flowAngleTwo * ftLocal ) * pow(this->flowAngleOne, 2.) / ( 1. + this->flowAngleOne * this->flowAngleTwo ) * hardening;
         m.at(2) = 2. * shearNorm;
-        m.at(3) = fabs(m.at(1) );
+        m.at(3) = fabs( m.at(1) );
     } else {   //circle
         m.at(1) = 2. * stress.at(1) / pow(this->flowAngleTwo, 2.) + 2. * ( fcLocal - this->flowAngleTwo * this->flowAngleOne * ftLocal ) / ( pow(this->flowAngleTwo, 2.) * ( 1. + this->flowAngleOne * this->flowAngleTwo ) ) * hardening;
         m.at(2) = 2. * shearNorm;
-        m.at(3) = fabs(m.at(1) );
+        m.at(3) = fabs( m.at(1) );
     }
 
     return m;
@@ -356,6 +356,8 @@ LatticePlasticityDamage::performPlasticityReturn(GaussPoint *gp,
                                                  const FloatArrayF< 6 > &reducedStrain,
                                                  TimeStep *tStep) const
 {
+    LatticePlasticityDamage_ReturnResult returnResult = RR_Unknown;
+
     double fcLocal =  giveCompressiveStrength(gp, tStep);
     auto status = static_cast< LatticePlasticityDamageStatus * >( this->giveStatus(gp) );
 
@@ -397,17 +399,17 @@ LatticePlasticityDamage::performPlasticityReturn(GaussPoint *gp,
         while ( returnResult == RR_NotConverged || subIncrementFlag == 1 ) {
             stress = mult(tangent, tempStrain - tempPlasticStrain);
 
-            tempKappa = performRegularReturn(stress, yieldValue, gp, tStep);
+            tempKappa = performRegularReturn(stress, returnResult, yieldValue, gp, tStep);
 
             if ( returnResult == RR_NotConverged ) {
                 subIncrementCounter++;
                 if ( subIncrementCounter > numberOfSubIncrements ) {
-                    OOFEM_LOG_INFO("Unstable element %d \n", gp->giveElement()->giveGlobalNumber() );
+                    OOFEM_LOG_INFO( "Unstable element %d \n", gp->giveElement()->giveGlobalNumber() );
                     OOFEM_LOG_INFO("Yield value %e \n", yieldValue);
-                    OOFEM_LOG_INFO("ConvergedStrain value %e %e %e\n", convergedStrain.at(1), convergedStrain.at(2), convergedStrain.at(3) );
-                    OOFEM_LOG_INFO("tempStrain value %e %e %e\n", tempStrain.at(1), tempStrain.at(2), tempStrain.at(3) );
-                    OOFEM_LOG_INFO("deltaStrain value %e %e %e\n", deltaStrain.at(1), deltaStrain.at(2), deltaStrain.at(3) );
-                    OOFEM_LOG_INFO("targetstrain value %e %e %e\n", strain.at(1), strain.at(2), strain.at(3) );
+                    OOFEM_LOG_INFO( "ConvergedStrain value %e %e %e\n", convergedStrain.at(1), convergedStrain.at(2), convergedStrain.at(3) );
+                    OOFEM_LOG_INFO( "tempStrain value %e %e %e\n", tempStrain.at(1), tempStrain.at(2), tempStrain.at(3) );
+                    OOFEM_LOG_INFO( "deltaStrain value %e %e %e\n", deltaStrain.at(1), deltaStrain.at(2), deltaStrain.at(3) );
+                    OOFEM_LOG_INFO( "targetstrain value %e %e %e\n", strain.at(1), strain.at(2), strain.at(3) );
 
                     OOFEM_ERROR("LatticePlasticityDamage :: performPlasticityReturn - Could not reach convergence with small deltaStrain, giving up.");
                 }
@@ -420,7 +422,7 @@ LatticePlasticityDamage::performPlasticityReturn(GaussPoint *gp,
                 tempPlasticStrain.at(2) = tempStrain.at(2) - stress.at(2) / ( this->alphaOne * eNormalMean );
                 tempPlasticStrain.at(3) = tempStrain.at(3) - stress.at(3) / ( this->alphaOne * eNormalMean );
 
-                status->letTempPlasticLatticeStrainBe(assemble< 6 >(tempPlasticStrain, { 0, 1, 2 }) );
+                status->letTempPlasticLatticeStrainBe( assemble< 6 >(tempPlasticStrain, { 0, 1, 2 }) );
                 status->setTempKappaP(tempKappa);
 
                 subIncrementFlag = 0;
@@ -440,7 +442,7 @@ LatticePlasticityDamage::performPlasticityReturn(GaussPoint *gp,
     tempPlasticStrain.at(2) = strain.at(2) - stress.at(2) / ( this->alphaOne * eNormalMean );
     tempPlasticStrain.at(3) = strain.at(3) - stress.at(3) / ( this->alphaOne * eNormalMean );
 
-    status->letTempPlasticLatticeStrainBe(assemble< 6 >(tempPlasticStrain, { 0, 1, 2 }) );
+    status->letTempPlasticLatticeStrainBe( assemble< 6 >(tempPlasticStrain, { 0, 1, 2 }) );
 
 
     //    status->letTempLatticeStressBe(assemble< 6 >(stress, { 0, 1, 2 }) );
@@ -456,6 +458,7 @@ LatticePlasticityDamage::performPlasticityReturn(GaussPoint *gp,
 
 double
 LatticePlasticityDamage::performRegularReturn(FloatArrayF< 3 > &stress,
+                                              LatticePlasticityDamage_ReturnResult &returnResult,
                                               double yieldValue,
                                               GaussPoint *gp,
                                               TimeStep *tStep) const
@@ -473,7 +476,7 @@ LatticePlasticityDamage::performRegularReturn(FloatArrayF< 3 > &stress,
 
     double tempShearStressNorm = trialShearStressNorm;
 
-    double thetaTrial = atan2(stress.at(3), stress.at(2) );
+    double thetaTrial = atan2( stress.at(3), stress.at(2) );
 
     // Do the same for kappa
     double kappa = status->giveKappaP();
@@ -715,7 +718,7 @@ LatticePlasticityDamage::performDamageEvaluation(GaussPoint *gp, FloatArrayF< 6 
     FloatArrayF< 6 >tempDamageLatticeStrain = omega * elasticReducedStrain;
     status->letTempDamageLatticeStrainBe(tempDamageLatticeStrain);
 
-    double crackWidth = norm(tempPlasticStrain + omega * ( reducedStrain - tempPlasticStrain ) ) * le;
+    double crackWidth = norm( tempPlasticStrain + omega * ( reducedStrain - tempPlasticStrain ) ) * le;
 
     //TODO: Compute dissipation
     // double tempDissipation = status->giveDissipation();

--- a/src/sm/Materials/LatticeMaterials/latticeplasticitydamage.h
+++ b/src/sm/Materials/LatticeMaterials/latticeplasticitydamage.h
@@ -82,6 +82,7 @@ protected:
 
     int compressionFlag = 0;
 
+
 public:
 
     /// Constructor
@@ -93,7 +94,7 @@ public:
 
     double giveKappaDOne() const { return kappaDOne; }
     double giveKappaDTwo() const { return kappaDTwo; }
-    //   double giveKappaDThree() { return kappaDThree; }
+
     double giveTempKappaDOne() const { return tempKappaDOne; }
     double giveTempKappaDTwo() const { return tempKappaDTwo; }
 
@@ -102,8 +103,6 @@ public:
     void   setTempKappaDOne(double newKappa) { tempKappaDOne = newKappa; }
 
     void   setTempKappaDTwo(double newKappa) { tempKappaDTwo = newKappa; }
-
-    //void   setTempKappaDThree(double newKappa) { tempKappaDThree = newKappa; }
 
     double giveDamage() const { return damage; }
 
@@ -128,6 +127,7 @@ public:
     void restoreContext(DataStream &stream, ContextMode mode) override;
 };
 
+
 /**
  * This class implements a local random plasticity damage model for concrete for lattice elements.
  */
@@ -135,8 +135,11 @@ class LatticePlasticityDamage : public LatticeLinearElastic
 {
 protected:
 
-    enum LatticePlasticityDamage_ReturnResult { RR_NotConverged, RR_Converged };
-    mutable LatticePlasticityDamage_ReturnResult returnResult = RR_NotConverged; /// FIXME: This must be removed. Not thread safe. Shouldn't be stored at all.
+    enum LatticePlasticityDamage_ReturnResult {
+        RR_Unknown,
+        RR_NotConverged,
+        RR_Converged
+    };
 
     double initialYieldStress = 0.;
 
@@ -171,11 +174,12 @@ protected:
 
     /// yield tolerance
     double yieldTol = 0.;
+
     /// maximum number of iterations for stress return
     int newtonIter = 0;
     int numberOfSubIncrements = 0;
 
-    //damageFlag
+    ///damageFlag
     int damageFlag = 0;
 
     virtual double giveTensileStrength(GaussPoint *gp, TimeStep *tStep) const { return this->give(ft_strength, gp) * this->ft; }
@@ -201,11 +205,6 @@ public:
 
     bool hasMaterialModeCapability(MaterialMode mode) const override;
 
-    // Doesn't exist? old code:
-    //FloatMatrix<X,X> computeBMatrix(const FloatArrayF<3> &sigma, const double deltaLambda) const;
-
-    /* FloatMatrixF< 3, 3 >computeAMatrix(const FloatArrayF< 3 > &sigma, const double tempKappa, */
-    /*                                    const double deltaLambda, GaussPoint *gp) const; */
 
     FloatArrayF< 3 >computeFVector(const FloatArrayF< 3 > &sigma, const double deltaLambda,
                                    GaussPoint *gp, TimeStep *tStep) const;
@@ -232,7 +231,7 @@ public:
                                  FloatArrayF< 6 > &reducedStrain,
                                  TimeStep *tStep) const;
 
-    double performRegularReturn(FloatArrayF< 3 > &stress, double yieldValue, GaussPoint *gp, TimeStep *tStep) const;
+    double performRegularReturn(FloatArrayF< 3 > &stress, LatticePlasticityDamage_ReturnResult &returnResult, double yieldValue, GaussPoint *gp, TimeStep *tStep) const;
 
     double computeYieldValue(const FloatArrayF< 3 > &sigma,
                              const double tempKappa,

--- a/src/sm/Materials/structuralmaterial.C
+++ b/src/sm/Materials/structuralmaterial.C
@@ -49,24 +49,24 @@
 #include "dynamicinputrecord.h"
 
 namespace oofem {
-std :: array< std :: array< int, 3 >, 3 >StructuralMaterial :: vIindex = {
+std::array< std::array< int, 3 >, 3 >StructuralMaterial::vIindex = {
     1, 6, 5,
     9, 2, 4,
     8, 7, 3
 };
 
-std :: array< std :: array< int, 3 >, 3 >StructuralMaterial :: svIndex = {
+std::array< std::array< int, 3 >, 3 >StructuralMaterial::svIndex = {
     1, 6, 5,
     6, 2, 4,
     5, 4, 3
 };
 
 
-StructuralMaterial :: StructuralMaterial(int n, Domain *d) : Material(n, d) { }
+StructuralMaterial::StructuralMaterial(int n, Domain *d) : Material(n, d) { }
 
 
 bool
-StructuralMaterial :: hasMaterialModeCapability(MaterialMode mode) const
+StructuralMaterial::hasMaterialModeCapability(MaterialMode mode) const
 //
 // returns whether receiver supports given mode
 //
@@ -77,7 +77,7 @@ StructuralMaterial :: hasMaterialModeCapability(MaterialMode mode) const
 
 
 void
-StructuralMaterial :: giveRealStressVector(FloatArray &answer, GaussPoint *gp, const FloatArray &reducedStrain, TimeStep *tStep)
+StructuralMaterial::giveRealStressVector(FloatArray &answer, GaussPoint *gp, const FloatArray &reducedStrain, TimeStep *tStep)
 {
     ///@todo Move this to StructuralCrossSection ?
     MaterialMode mode = gp->giveMaterialMode();
@@ -106,21 +106,21 @@ StructuralMaterial :: giveRealStressVector(FloatArray &answer, GaussPoint *gp, c
 
 
 FloatArrayF< 6 >
-StructuralMaterial :: giveRealStressVector_3d(const FloatArrayF< 6 > &strain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_3d(const FloatArrayF< 6 > &strain, GaussPoint *gp, TimeStep *tStep) const
 {
     OOFEM_ERROR("3d mode not supported");
 }
 
 
 FloatArrayF< 2 >
-StructuralMaterial :: giveRealStressVector_Warping(const FloatArrayF< 2 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_Warping(const FloatArrayF< 2 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     OOFEM_ERROR("Warping mode not supported");
 }
 
 
 FloatArrayF< 4 >
-StructuralMaterial :: giveRealStressVector_PlaneStrain(const FloatArrayF< 4 > &strain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_PlaneStrain(const FloatArrayF< 4 > &strain, GaussPoint *gp, TimeStep *tStep) const
 {
     auto vS = this->giveRealStressVector_3d(assemble< 6 >(strain, { 0, 1, 2, 5 }), gp, tStep);
     return vS [ { 0, 1, 2, 5 } ];
@@ -128,7 +128,7 @@ StructuralMaterial :: giveRealStressVector_PlaneStrain(const FloatArrayF< 4 > &s
 
 
 FloatArray
-StructuralMaterial :: giveRealStressVector_StressControl(const FloatArray &reducedStrain, const IntArray &strainControl, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_StressControl(const FloatArray &reducedStrain, const IntArray &strainControl, GaussPoint *gp, TimeStep *tStep) const
 {
     auto status = static_cast< StructuralMaterialStatus * >( this->giveStatus(gp) );
 
@@ -138,7 +138,7 @@ StructuralMaterial :: giveRealStressVector_StressControl(const FloatArray &reduc
     // Iterate to find full vE.
     // Compute the negated the array of control since we need stressControl as well;
 
-    stressControl.resize(6 - strainControl.giveSize() );
+    stressControl.resize( 6 - strainControl.giveSize() );
     for ( int i = 1, j = 1; i <= 6; i++ ) {
         if ( !strainControl.contains(i) ) {
             stressControl.at(j++) = i;
@@ -148,12 +148,12 @@ StructuralMaterial :: giveRealStressVector_StressControl(const FloatArray &reduc
     // Initial guess;
     vE = status->giveStrainVector();
     for ( int i = 1; i <= strainControl.giveSize(); ++i ) {
-        vE.at(strainControl.at(i) ) = reducedStrain.at(i);
+        vE.at( strainControl.at(i) ) = reducedStrain.at(i);
     }
 
     // Iterate to find full vE.
     FloatArray answer;
-    for ( int k = 0; k < 100; k++ ) { // Allow for a generous 100 iterations.
+    for ( int k = 0; k < 100000; k++ ) { // Allow for a generous 100000 iterations.
         vS = this->giveRealStressVector_3d(vE, gp, tStep);
         // For debugging the iterations:
         //vE.printYourself("vE");
@@ -161,7 +161,7 @@ StructuralMaterial :: giveRealStressVector_StressControl(const FloatArray &reduc
         reducedvS.beSubArrayOf(vS, stressControl);
         // Pick out the (response) stresses for the controlled strains
         answer.beSubArrayOf(vS, strainControl);
-        if ( reducedvS.computeNorm() <= 1e-6 * vS.computeNorm() && k >= 1 ) { // Absolute tolerance right now (with at least one iteration)
+        if ( reducedvS.computeNorm() <= 1e-3 * vS.computeNorm() && k >= 1 ) { // Absolute tolerance right now (with at least one iteration)
             ///@todo We need a relative tolerance here!
             /// A relative tolerance like this could work, but if a really small increment is performed it won't work
             /// (it will be limited by machine precision)
@@ -177,13 +177,13 @@ StructuralMaterial :: giveRealStressVector_StressControl(const FloatArray &reduc
         //vE.printYourself("vE");
     }
 
-    OOFEM_ERROR("Iteration did not converge");
+    OOFEM_ERROR( "Iteration did not converge after 100000 iterations. The error is %e", reducedvS.computeNorm() );
     return FloatArray();
 }
 
 
 FloatArray
-StructuralMaterial :: giveRealStressVector_ShellStressControl(const FloatArray &strain, const IntArray &strainControl, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_ShellStressControl(const FloatArray &strain, const IntArray &strainControl, GaussPoint *gp, TimeStep *tStep) const
 // calculates stress vector (6 components) with assumption of sigma_z = 0
 // used by MITC4Shell
 {
@@ -195,7 +195,7 @@ StructuralMaterial :: giveRealStressVector_ShellStressControl(const FloatArray &
     // Iterate to find full vE.
     // Compute the negated the array of control since we need stressControl as well;
 
-    stressControl.resize(6 - strainControl.giveSize() );
+    stressControl.resize( 6 - strainControl.giveSize() );
     for ( int i = 1, j = 1; i <= 6; i++ ) {
         if ( !strainControl.contains(i) ) {
             stressControl.at(j++) = i;
@@ -234,65 +234,65 @@ StructuralMaterial :: giveRealStressVector_ShellStressControl(const FloatArray &
 
 
 FloatArrayF< 3 >
-StructuralMaterial :: giveRealStressVector_PlaneStress(const FloatArrayF< 3 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_PlaneStress(const FloatArrayF< 3 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     IntArray strainControl;
-    StructuralMaterial :: giveVoigtSymVectorMask(strainControl, _PlaneStress);
+    StructuralMaterial::giveVoigtSymVectorMask(strainControl, _PlaneStress);
     return this->giveRealStressVector_StressControl(reducedStrain, strainControl, gp, tStep);
 }
 
 
 FloatArrayF< 1 >
-StructuralMaterial :: giveRealStressVector_1d(const FloatArrayF< 1 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_1d(const FloatArrayF< 1 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     IntArray strainControl;
-    StructuralMaterial :: giveVoigtSymVectorMask(strainControl, _1dMat);
+    StructuralMaterial::giveVoigtSymVectorMask(strainControl, _1dMat);
     return this->giveRealStressVector_StressControl(reducedStrain, strainControl, gp, tStep);
 }
 
 
 FloatArrayF< 2 >
-StructuralMaterial :: giveRealStressVector_2dBeamLayer(const FloatArrayF< 2 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_2dBeamLayer(const FloatArrayF< 2 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     IntArray strainControl;
-    StructuralMaterial :: giveVoigtSymVectorMask(strainControl, _2dBeamLayer);
+    StructuralMaterial::giveVoigtSymVectorMask(strainControl, _2dBeamLayer);
     return this->giveRealStressVector_StressControl(reducedStrain, strainControl, gp, tStep);
 }
 
 
 FloatArrayF< 5 >
-StructuralMaterial :: giveRealStressVector_PlateLayer(const FloatArrayF< 5 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_PlateLayer(const FloatArrayF< 5 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     IntArray strainControl;
-    StructuralMaterial :: giveVoigtSymVectorMask(strainControl, _PlateLayer);
+    StructuralMaterial::giveVoigtSymVectorMask(strainControl, _PlateLayer);
     return this->giveRealStressVector_StressControl(reducedStrain, strainControl, gp, tStep);
 }
 
 
 FloatArrayF< 3 >
-StructuralMaterial :: giveRealStressVector_Fiber(const FloatArrayF< 3 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_Fiber(const FloatArrayF< 3 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     IntArray strainControl;
-    StructuralMaterial :: giveVoigtSymVectorMask(strainControl, _Fiber);
+    StructuralMaterial::giveVoigtSymVectorMask(strainControl, _Fiber);
     return this->giveRealStressVector_StressControl(reducedStrain, strainControl, gp, tStep);
 }
 
 
 FloatArrayF< 3 >
-StructuralMaterial :: giveRealStressVector_2dPlateSubSoil(const FloatArrayF< 3 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_2dPlateSubSoil(const FloatArrayF< 3 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     OOFEM_ERROR("2dPlateSubSoil mode not supported");
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: giveRealStressVector_3dBeamSubSoil(const FloatArrayF< 6 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveRealStressVector_3dBeamSubSoil(const FloatArrayF< 6 > &reducedStrain, GaussPoint *gp, TimeStep *tStep) const
 {
     OOFEM_ERROR("3dBeamSubSoil mode not supported");
 }
 
 
 FloatArrayF< 9 >
-StructuralMaterial :: giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, GaussPoint *gp, TimeStep *tStep) const
 {
     // Default implementation used if this method is not overloaded by the particular material model.
     // 1) Compute Green-Lagrange strain and call standard method for small strains.
@@ -317,7 +317,7 @@ StructuralMaterial :: giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, Gau
 
 
 FloatArrayF< 5 >
-StructuralMaterial :: giveFirstPKStressVector_PlaneStrain(const FloatArrayF< 5 > &vF, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveFirstPKStressVector_PlaneStrain(const FloatArrayF< 5 > &vF, GaussPoint *gp, TimeStep *tStep) const
 {
     auto vP = this->giveFirstPKStressVector_3d(assemble< 9 >(vF, { 0, 1, 2, 5, 8 }), gp, tStep);
     return vP [ { 0, 1, 2, 5, 8 } ];
@@ -328,16 +328,16 @@ StructuralMaterial :: giveFirstPKStressVector_PlaneStrain(const FloatArrayF< 5 >
 
 
 FloatArray
-StructuralMaterial :: giveFirstPKStressVector_StressControl(const FloatArray &reducedvF, const IntArray &F_control, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveFirstPKStressVector_StressControl(const FloatArray &reducedvF, const IntArray &F_control, GaussPoint *gp, TimeStep *tStep) const
 {
     auto status = static_cast< StructuralMaterialStatus * >( this->giveStatus(gp) );
-    
+
     IntArray P_control;
     FloatArray vF, increment_vF, vP, reducedvP;
     FloatMatrix tangent, reducedTangent;
     // Iterate to find full vF.
     // Compute the negated the array of control since we need stressControl as well;
-    P_control.resize( 9 - F_control.giveSize() );
+    P_control.resize(9 - F_control.giveSize() );
     for ( int i = 1, j = 1; i <= 9; i++ ) {
         if ( !F_control.contains(i) ) {
             P_control.at(j++) = i;
@@ -347,7 +347,7 @@ StructuralMaterial :: giveFirstPKStressVector_StressControl(const FloatArray &re
     // Initial guess;
     vF = status->giveFVector();
     for ( int i = 1; i <= F_control.giveSize(); ++i ) {
-        vF.at( F_control.at(i) ) = reducedvF.at(i);
+        vF.at(F_control.at(i) ) = reducedvF.at(i);
     }
 
     // Iterate to find full vF.
@@ -357,17 +357,17 @@ StructuralMaterial :: giveFirstPKStressVector_StressControl(const FloatArray &re
         reducedvP.beSubArrayOf(vP, P_control);
         // Pick out the (response) stresses for the controlled strains
         answer.beSubArrayOf(vP, F_control);
-	if ( reducedvP.computeNorm() <= 1e-6 * answer.computeNorm() && k >= 1 ) {
-	  return answer;
+        if ( reducedvP.computeNorm() <= 1e-6 * answer.computeNorm() && k >= 1 ) {
+            return answer;
         }
 
-	tangent = this->give3dMaterialStiffnessMatrix_dPdF(TangentStiffness, gp, tStep);
+        tangent = this->give3dMaterialStiffnessMatrix_dPdF(TangentStiffness, gp, tStep);
         reducedTangent.beSubMatrixOf(tangent, P_control, P_control);
         reducedTangent.solveForRhs(reducedvP, increment_vF);
         increment_vF.negated();
         vF.assemble(increment_vF, P_control);
     }
-    
+
     OOFEM_ERROR("Iteration did not converge");
     return FloatArray();
 }
@@ -376,25 +376,25 @@ StructuralMaterial :: giveFirstPKStressVector_StressControl(const FloatArray &re
 
 
 FloatArrayF< 4 >
-StructuralMaterial :: giveFirstPKStressVector_PlaneStress(const FloatArrayF< 4 > &reducedvF, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveFirstPKStressVector_PlaneStress(const FloatArrayF< 4 > &reducedvF, GaussPoint *gp, TimeStep *tStep) const
 {
     IntArray FControl;
-    StructuralMaterial :: giveVoigtVectorMask(FControl, _PlaneStress);
+    StructuralMaterial::giveVoigtVectorMask(FControl, _PlaneStress);
     return this->giveRealStressVector_StressControl(reducedvF, FControl, gp, tStep);
 }
 
 
 FloatArrayF< 1 >
-StructuralMaterial :: giveFirstPKStressVector_1d(const FloatArrayF< 1 > &reducedvF, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveFirstPKStressVector_1d(const FloatArrayF< 1 > &reducedvF, GaussPoint *gp, TimeStep *tStep) const
 {
     IntArray FControl;
-    StructuralMaterial :: giveVoigtVectorMask(FControl, _PlaneStress);
+    StructuralMaterial::giveVoigtVectorMask(FControl, _PlaneStress);
     return this->giveRealStressVector_StressControl(reducedvF, FControl, gp, tStep);
 }
 
 
 FloatMatrixF< 9, 9 >
-StructuralMaterial :: convert_dSdE_2_dPdF_3D(const FloatMatrixF< 6, 6 > &C, const FloatArrayF< 6 > &S, const FloatArrayF< 9 > &F)
+StructuralMaterial::convert_dSdE_2_dPdF_3D(const FloatMatrixF< 6, 6 > &C, const FloatArrayF< 6 > &S, const FloatArrayF< 9 > &F)
 {
     // Converts the reduced dSdE-stiffness to reduced dPdF-sitiffness for different MaterialModes
     // Performs the following operation dPdF = I_ik * S_jl + F_im F_kn C_mjnl,
@@ -499,7 +499,7 @@ StructuralMaterial :: convert_dSdE_2_dPdF_3D(const FloatMatrixF< 6, 6 > &C, cons
                 for ( int l = 1; l <= 3; l++ ) {
                     for ( int m = 1; m <= 3; m++ ) {
                         for ( int n = 1; n <= 3; n++ ) {
-                            answer.at(giveVI(i, j), giveVI(k, l) ) += I.at(i, k) * S.at(giveSymVI(j, l) ) + F.at(giveVI(i, m) ) * F.at(giveVI(k, n) ) * C.at(giveSymVI(m, j), giveSymVI(n, l) );
+                            answer.at( giveVI(i, j), giveVI(k, l) ) += I.at(i, k) * S.at( giveSymVI(j, l) ) + F.at( giveVI(i, m) ) * F.at( giveVI(k, n) ) * C.at( giveSymVI(m, j), giveSymVI(n, l) );
                         }
                     }
                 }
@@ -511,7 +511,7 @@ StructuralMaterial :: convert_dSdE_2_dPdF_3D(const FloatMatrixF< 6, 6 > &C, cons
 }
 
 FloatMatrixF< 5, 5 >
-StructuralMaterial :: convert_dSdE_2_dPdF_PlaneStrain(const FloatMatrixF< 4, 4 > &C, const FloatArrayF< 4 > &S, const FloatArrayF< 5 > &F)
+StructuralMaterial::convert_dSdE_2_dPdF_PlaneStrain(const FloatMatrixF< 4, 4 > &C, const FloatArrayF< 4 > &S, const FloatArrayF< 5 > &F)
 {
     //Save terms associated with H = [du/dx, dv/dy, dw/dz, du/dy, dv/dx] //@todo not fully checked
     FloatMatrixF< 5, 5 >answer;
@@ -544,7 +544,7 @@ StructuralMaterial :: convert_dSdE_2_dPdF_PlaneStrain(const FloatMatrixF< 4, 4 >
 }
 
 FloatMatrixF< 4, 4 >
-StructuralMaterial :: convert_dSdE_2_dPdF_PlaneStress(const FloatMatrixF< 3, 3 > &C, const FloatArrayF< 3 > &S, const FloatArrayF< 4 > &F)
+StructuralMaterial::convert_dSdE_2_dPdF_PlaneStress(const FloatMatrixF< 3, 3 > &C, const FloatArrayF< 3 > &S, const FloatArrayF< 4 > &F)
 {
     // Save terms associated with H = [du/dx dv/dy du/dy dv/dx]
     FloatMatrixF< 4, 4 >answer;
@@ -568,7 +568,7 @@ StructuralMaterial :: convert_dSdE_2_dPdF_PlaneStress(const FloatMatrixF< 3, 3 >
 }
 
 FloatMatrixF< 1, 1 >
-StructuralMaterial :: convert_dSdE_2_dPdF_1D(const FloatMatrixF< 1, 1 > &C, const FloatArrayF< 1 > &S, const FloatArrayF< 1 > &F)
+StructuralMaterial::convert_dSdE_2_dPdF_1D(const FloatMatrixF< 1, 1 > &C, const FloatArrayF< 1 > &S, const FloatArrayF< 1 > &F)
 {
     //Save terms associated with H = [du/dx]
     /// @todo is this really correct??
@@ -579,16 +579,16 @@ StructuralMaterial :: convert_dSdE_2_dPdF_1D(const FloatMatrixF< 1, 1 > &C, cons
 
 
 void
-StructuralMaterial :: giveEshelbyStressVector_PlaneStrain(FloatArray &answer, GaussPoint *gp, const FloatArray &reducedF, TimeStep *tStep)
+StructuralMaterial::giveEshelbyStressVector_PlaneStrain(FloatArray &answer, GaussPoint *gp, const FloatArray &reducedF, TimeStep *tStep)
 {
     OOFEM_ERROR("not implemented ")
 }
 
 
 void
-StructuralMaterial :: giveStiffnessMatrix(FloatMatrix &answer,
-                                          MatResponseMode rMode,
-                                          GaussPoint *gp, TimeStep *tStep)
+StructuralMaterial::giveStiffnessMatrix(FloatMatrix &answer,
+                                        MatResponseMode rMode,
+                                        GaussPoint *gp, TimeStep *tStep)
 //
 // Returns characteristic material stiffness matrix of the receiver
 //
@@ -620,14 +620,14 @@ StructuralMaterial :: giveStiffnessMatrix(FloatMatrix &answer,
         answer = eye< 2 >();
         break;
     default:
-        OOFEM_ERROR("unknown mode (%s)", __MaterialModeToString(mMode) );
+        OOFEM_ERROR( "unknown mode (%s)", __MaterialModeToString(mMode) );
     }
 }
 
 
 FloatMatrixF< 9, 9 >
-StructuralMaterial :: give3dMaterialStiffnessMatrix_dPdF(MatResponseMode mode,
-                                                         GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::give3dMaterialStiffnessMatrix_dPdF(MatResponseMode mode,
+                                                       GaussPoint *gp, TimeStep *tStep) const
 {
     auto status = static_cast< StructuralMaterialStatus * >( this->giveStatus(gp) );
     const auto &vF = status->giveTempFVector();
@@ -638,28 +638,27 @@ StructuralMaterial :: give3dMaterialStiffnessMatrix_dPdF(MatResponseMode mode,
 
 
 FloatMatrixF< 5, 5 >
-StructuralMaterial :: givePlaneStrainStiffMtrx_dPdF(MatResponseMode mode,
-                                                    GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::givePlaneStrainStiffMtrx_dPdF(MatResponseMode mode,
+                                                  GaussPoint *gp, TimeStep *tStep) const
 {
-
     auto m3d = this->give3dMaterialStiffnessMatrix_dPdF(mode, gp, tStep);
     return m3d({ 0, 1, 2, 5, 8 }, { 0, 1, 2, 5, 8 });
 }
 
 
 FloatMatrixF< 4, 4 >
-StructuralMaterial :: givePlaneStressStiffMtrx_dPdF(MatResponseMode mode,
-                                                    GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::givePlaneStressStiffMtrx_dPdF(MatResponseMode mode,
+                                                  GaussPoint *gp, TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix_dPdF(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 1, 5, 8 }, { 0, 1, 5, 8 }) );
+    return inv( c3d({ 0, 1, 5, 8 }, { 0, 1, 5, 8 }) );
 }
 
 
 FloatMatrixF< 1, 1 >
-StructuralMaterial :: give1dStressStiffMtrx_dPdF(MatResponseMode mode,
-                                                 GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::give1dStressStiffMtrx_dPdF(MatResponseMode mode,
+                                               GaussPoint *gp, TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
@@ -668,9 +667,9 @@ StructuralMaterial :: give1dStressStiffMtrx_dPdF(MatResponseMode mode,
 
 
 void
-StructuralMaterial :: give3dMaterialStiffnessMatrix_dCde(FloatMatrix &answer,
-                                                         MatResponseMode mode,
-                                                         GaussPoint *gp, TimeStep *tStep)
+StructuralMaterial::give3dMaterialStiffnessMatrix_dCde(FloatMatrix &answer,
+                                                       MatResponseMode mode,
+                                                       GaussPoint *gp, TimeStep *tStep)
 {
     ///@todo what should be default implementaiton?
     OOFEM_ERROR("There is no default implementation");
@@ -678,36 +677,36 @@ StructuralMaterial :: give3dMaterialStiffnessMatrix_dCde(FloatMatrix &answer,
 
 
 void
-StructuralMaterial :: givePlaneStressStiffMtrx_dCde(FloatMatrix &answer,
-                                                    MatResponseMode mode,
-                                                    GaussPoint *gp, TimeStep *tStep)
+StructuralMaterial::givePlaneStressStiffMtrx_dCde(FloatMatrix &answer,
+                                                  MatResponseMode mode,
+                                                  GaussPoint *gp, TimeStep *tStep)
 {
     OOFEM_ERROR("There is no default implementation");
 }
 
 
 void
-StructuralMaterial :: givePlaneStrainStiffMtrx_dCde(FloatMatrix &answer,
-                                                    MatResponseMode mode,
-                                                    GaussPoint *gp, TimeStep *tStep)
+StructuralMaterial::givePlaneStrainStiffMtrx_dCde(FloatMatrix &answer,
+                                                  MatResponseMode mode,
+                                                  GaussPoint *gp, TimeStep *tStep)
 {
     OOFEM_ERROR("There is no default implementation");
 }
 
 
 void
-StructuralMaterial :: give1dStressStiffMtrx_dCde(FloatMatrix &answer,
-                                                 MatResponseMode mode,
-                                                 GaussPoint *gp, TimeStep *tStep)
+StructuralMaterial::give1dStressStiffMtrx_dCde(FloatMatrix &answer,
+                                               MatResponseMode mode,
+                                               GaussPoint *gp, TimeStep *tStep)
 {
     OOFEM_ERROR("There is no default implementation");
 }
 
 
 void
-StructuralMaterial :: giveStressDependentPartOfStrainVector(FloatArray &answer, GaussPoint *gp,
-                                                            const FloatArray &reducedStrainVector,
-                                                            TimeStep *tStep, ValueModeType mode) const
+StructuralMaterial::giveStressDependentPartOfStrainVector(FloatArray &answer, GaussPoint *gp,
+                                                          const FloatArray &reducedStrainVector,
+                                                          TimeStep *tStep, ValueModeType mode) const
 {
     /*
      * This functions subtract from reducedStrainVector its stress independent part
@@ -722,37 +721,37 @@ StructuralMaterial :: giveStressDependentPartOfStrainVector(FloatArray &answer, 
 
 
 int
-StructuralMaterial :: giveSizeOfVoigtSymVector(MaterialMode mode)
+StructuralMaterial::giveSizeOfVoigtSymVector(MaterialMode mode)
 {
     IntArray indx;
-    StructuralMaterial :: giveVoigtSymVectorMask(indx, mode);
+    StructuralMaterial::giveVoigtSymVectorMask(indx, mode);
     return indx.giveSize();
 }
 
 
 int
-StructuralMaterial :: giveSizeOfVoigtVector(MaterialMode mode)
+StructuralMaterial::giveSizeOfVoigtVector(MaterialMode mode)
 {
     IntArray indx;
-    StructuralMaterial :: giveVoigtVectorMask(indx, mode);
+    StructuralMaterial::giveVoigtVectorMask(indx, mode);
     return indx.giveSize();
 }
 
 
 void
-StructuralMaterial :: giveInvertedVoigtVectorMask(IntArray &answer, MaterialMode mmode)
+StructuralMaterial::giveInvertedVoigtVectorMask(IntArray &answer, MaterialMode mmode)
 {
     IntArray mask;
-    answer.resize(StructuralMaterial :: giveVoigtSymVectorMask(mask, mmode) );
+    answer.resize( StructuralMaterial::giveVoigtSymVectorMask(mask, mmode) );
     answer.zero();
     for ( int i = 1; i <= mask.giveSize(); i++ ) {
-        answer.at(mask.at(i) ) = i;
+        answer.at( mask.at(i) ) = i;
     }
 }
 
 
 int
-StructuralMaterial :: giveVoigtSymVectorMask(IntArray &answer, MaterialMode mmode)
+StructuralMaterial::giveVoigtSymVectorMask(IntArray &answer, MaterialMode mmode)
 {
     // The same as giveVoigtVectorMask but returns a mask corresponding to a symmetric
     // second order tensor.
@@ -910,7 +909,7 @@ StructuralMaterial :: giveVoigtSymVectorMask(IntArray &answer, MaterialMode mmod
 
 
 int
-StructuralMaterial :: giveVoigtVectorMask(IntArray &answer, MaterialMode mmode)
+StructuralMaterial::giveVoigtVectorMask(IntArray &answer, MaterialMode mmode)
 {
     // Returns a mask of the vector indices corresponding to components in a general
     // (non-symmetric) second order tensor of some stress/strain/deformation measure that
@@ -960,85 +959,85 @@ StructuralMaterial :: giveVoigtVectorMask(IntArray &answer, MaterialMode mmode)
 
 
 FloatMatrixF< 3, 3 >
-StructuralMaterial :: givePlaneStressStiffMtrx(MatResponseMode mode,
-                                               GaussPoint *gp,
-                                               TimeStep *tStep) const
+StructuralMaterial::givePlaneStressStiffMtrx(MatResponseMode mode,
+                                             GaussPoint *gp,
+                                             TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 1, 5 }, { 0, 1, 5 }) );
+    return inv( c3d({ 0, 1, 5 }, { 0, 1, 5 }) );
 }
 
 FloatMatrixF< 4, 4 >
-StructuralMaterial :: givePlaneStrainStiffMtrx(MatResponseMode mode,
-                                               GaussPoint *gp,
-                                               TimeStep *tStep) const
+StructuralMaterial::givePlaneStrainStiffMtrx(MatResponseMode mode,
+                                             GaussPoint *gp,
+                                             TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     return m3d({ 0, 1, 2, 5 }, { 0, 1, 2, 5 });
 }
 
 FloatMatrixF< 1, 1 >
-StructuralMaterial :: give1dStressStiffMtrx(MatResponseMode mode,
-                                            GaussPoint *gp,
-                                            TimeStep *tStep) const
+StructuralMaterial::give1dStressStiffMtrx(MatResponseMode mode,
+                                          GaussPoint *gp,
+                                          TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
     return {
-               1. / c3d.at(1, 1)
+        1. / c3d.at(1, 1)
     };
 }
 
 
 FloatMatrixF< 2, 2 >
-StructuralMaterial :: give2dBeamLayerStiffMtrx(MatResponseMode mode,
-                                               GaussPoint *gp,
-                                               TimeStep *tStep) const
+StructuralMaterial::give2dBeamLayerStiffMtrx(MatResponseMode mode,
+                                             GaussPoint *gp,
+                                             TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 4 }, { 0, 4 }) );
+    return inv( c3d({ 0, 4 }, { 0, 4 }) );
 }
 
 
 FloatMatrixF< 5, 5 >
-StructuralMaterial :: givePlateLayerStiffMtrx(MatResponseMode mode,
-                                              GaussPoint *gp,
-                                              TimeStep *tStep) const
+StructuralMaterial::givePlateLayerStiffMtrx(MatResponseMode mode,
+                                            GaussPoint *gp,
+                                            TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 1, 3, 4, 5 }, { 0, 1, 3, 4, 5 }) );
+    return inv( c3d({ 0, 1, 3, 4, 5 }, { 0, 1, 3, 4, 5 }) );
 }
 
 FloatMatrixF< 3, 3 >
-StructuralMaterial :: giveFiberStiffMtrx(MatResponseMode mode,
-                                         GaussPoint *gp,
-                                         TimeStep *tStep) const
+StructuralMaterial::giveFiberStiffMtrx(MatResponseMode mode,
+                                       GaussPoint *gp,
+                                       TimeStep *tStep) const
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 4, 5 }, { 0, 4, 5 }) );
+    return inv( c3d({ 0, 4, 5 }, { 0, 4, 5 }) );
 }
 
 
 FloatMatrixF< 3, 3 >
-StructuralMaterial :: give2dPlateSubSoilStiffMtrx(MatResponseMode mmode, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::give2dPlateSubSoilStiffMtrx(MatResponseMode mmode, GaussPoint *gp, TimeStep *tStep) const
 {
     OOFEM_ERROR("No general implementation provided");
     return FloatMatrixF< 3, 3 >();
 }
 
 FloatMatrixF< 6, 6 >
-StructuralMaterial :: give3dBeamSubSoilStiffMtrx(MatResponseMode mmode, GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::give3dBeamSubSoilStiffMtrx(MatResponseMode mmode, GaussPoint *gp, TimeStep *tStep) const
 {
     OOFEM_ERROR("No general implementation provided");
     return FloatMatrixF< 6, 6 >();
 }
 
 void
-StructuralMaterial :: computePrincipalValues(FloatArray &answer, const FloatArray &s, stressStrainPrincMode mode)
+StructuralMaterial::computePrincipalValues(FloatArray &answer, const FloatArray &s, stressStrainPrincMode mode)
 //
 // This function computes the principal values of strains or stresses.
 // Strains/stresses are stored in vector form in array s.
@@ -1080,7 +1079,7 @@ StructuralMaterial :: computePrincipalValues(FloatArray &answer, const FloatArra
         answer.resize(size - 1);
 
         for ( int i = 1; i <= size; i++ ) {
-            if ( fabs(s.at(i) ) > 1.e-20 ) {
+            if ( fabs( s.at(i) ) > 1.e-20 ) {
                 nonzeroFlag = 1;
             }
         }
@@ -1115,7 +1114,7 @@ StructuralMaterial :: computePrincipalValues(FloatArray &answer, const FloatArra
         double I1 = 0.0, I2 = 0.0, I3 = 0.0, help, s1, s2, s3;
 
         for ( int i = 1; i <= size; i++ ) {
-            if ( fabs(s.at(i) ) > 1.e-20 ) {
+            if ( fabs( s.at(i) ) > 1.e-20 ) {
                 nonzeroFlag = 1;
             }
         }
@@ -1159,7 +1158,7 @@ StructuralMaterial :: computePrincipalValues(FloatArray &answer, const FloatArra
          */
         int n;
         if ( solve ) {
-            cubic3r( ( double ) -1., I1, -I2, I3, & s1, & s2, & s3, & n );
+            cubic3r( ( double ) -1., I1, -I2, I3, & s1, & s2, & s3, & n);
             if ( n > 0 ) {
                 answer.at(1) = s1;
             }
@@ -1197,7 +1196,7 @@ StructuralMaterial :: computePrincipalValues(FloatArray &answer, const FloatArra
 
 
 FloatArrayF< 3 >
-StructuralMaterial :: computePrincipalValues(const FloatMatrixF< 3, 3 > &s)
+StructuralMaterial::computePrincipalValues(const FloatMatrixF< 3, 3 > &s)
 {
     double I1 = s(0, 0) + s(1, 1) + s(2, 2);
     double I2 = s(0, 0) * s(1, 1) + s(1, 1) * s(2, 2) + s(2, 2) * s(0, 0) -
@@ -1210,7 +1209,7 @@ StructuralMaterial :: computePrincipalValues(const FloatMatrixF< 3, 3 > &s)
 
 
 FloatArrayF< 3 >
-StructuralMaterial :: computePrincipalValues(double I1, double I2, double I3)
+StructuralMaterial::computePrincipalValues(double I1, double I2, double I3)
 {
     double CUBIC_ZERO = 1e-100;
     double q = ( I1 * I1 - 3.0 * I2 ) / 9.0;
@@ -1220,7 +1219,7 @@ StructuralMaterial :: computePrincipalValues(double I1, double I2, double I3)
     //Hydrostatic case, in such a case q=r=0
     if ( ( fabs(q) < CUBIC_ZERO ) && ( fabs(r) < CUBIC_ZERO ) ) {
         return {
-                   a3, a3, a3
+            a3, a3, a3
         };
     }
 
@@ -1235,20 +1234,20 @@ StructuralMaterial :: computePrincipalValues(double I1, double I2, double I3)
         a3 - p * cos(phi + 2. * M_PI / 3.),
     };
     if ( v [ 0 ] > v [ 1 ] ) {
-        std :: swap(v [ 0 ], v [ 1 ]);
+        std::swap(v [ 0 ], v [ 1 ]);
     }
     if ( v [ 1 ] > v [ 2 ] ) {
-        std :: swap(v [ 1 ], v [ 2 ]);
+        std::swap(v [ 1 ], v [ 2 ]);
     }
     if ( v [ 0 ] > v [ 1 ] ) {
-        std :: swap(v [ 0 ], v [ 1 ]);
+        std::swap(v [ 0 ], v [ 1 ]);
     }
     return v;
 }
 
 
-std :: pair< FloatArrayF< 3 >, FloatMatrixF< 3, 3 > >
-StructuralMaterial :: computePrincipalValDir(const FloatMatrixF< 3, 3 > &s)
+std::pair< FloatArrayF< 3 >, FloatMatrixF< 3, 3 > >
+StructuralMaterial::computePrincipalValDir(const FloatMatrixF< 3, 3 > &s)
 {
     //auto [eigVal, eigVec] = eig(s, 10);
     auto tmp = eig(s, 10);
@@ -1256,9 +1255,9 @@ StructuralMaterial :: computePrincipalValDir(const FloatMatrixF< 3, 3 > &s)
     for ( int ii = 0; ii < 2; ii++ ) {
         for ( int jj = 0; jj < 2; jj++ ) {
             if ( tmp.first [ jj + 1 ] > tmp.first [ jj ] ) {
-                std :: swap(tmp.first [ jj ], tmp.first [ jj + 1 ]);
+                std::swap(tmp.first [ jj ], tmp.first [ jj + 1 ]);
                 for ( int kk = 0; kk < 3; kk++ ) {
-                    std :: swap(tmp.second(kk, jj), tmp.second(kk, jj + 1) );
+                    std::swap( tmp.second(kk, jj), tmp.second(kk, jj + 1) );
                 }
             }
         }
@@ -1268,7 +1267,7 @@ StructuralMaterial :: computePrincipalValDir(const FloatMatrixF< 3, 3 > &s)
 
 
 void
-StructuralMaterial :: computePrincipalValDir(FloatArray &answer, FloatMatrix &dir, const FloatArray &s, stressStrainPrincMode mode)
+StructuralMaterial::computePrincipalValDir(FloatArray &answer, FloatMatrix &dir, const FloatArray &s, stressStrainPrincMode mode)
 //
 // This function computes the principal values & directions corresponding to principal values
 // of strains or streses.
@@ -1321,7 +1320,7 @@ StructuralMaterial :: computePrincipalValDir(FloatArray &answer, FloatMatrix &di
         dir.resize(2, 2);
 
         for ( int i = 1; i <= size; i++ ) {
-            if ( fabs(s.at(i) ) > 1.e-20 ) {
+            if ( fabs( s.at(i) ) > 1.e-20 ) {
                 nonzeroFlag = 1;
             }
         }
@@ -1351,7 +1350,7 @@ StructuralMaterial :: computePrincipalValDir(FloatArray &answer, FloatMatrix &di
         dir.resize(3, 3);
 
         for ( int i = 1; i <= size; i++ ) {
-            if ( fabs(s.at(i) ) > 1.e-20 ) {
+            if ( fabs( s.at(i) ) > 1.e-20 ) {
                 nonzeroFlag = 1;
             }
         }
@@ -1419,8 +1418,8 @@ StructuralMaterial :: computePrincipalValDir(FloatArray &answer, FloatMatrix &di
 }
 
 
-std :: pair< FloatArrayF< 6 >, double >
-StructuralMaterial :: computeDeviatoricVolumetricSplit(const FloatArrayF< 6 > &s)
+std::pair< FloatArrayF< 6 >, double >
+StructuralMaterial::computeDeviatoricVolumetricSplit(const FloatArrayF< 6 > &s)
 {
     double vol = s [ 0 ] + s [ 1 ] + s [ 2 ];
     double mean = vol / 3.0;
@@ -1429,13 +1428,13 @@ StructuralMaterial :: computeDeviatoricVolumetricSplit(const FloatArrayF< 6 > &s
     dev.at(2) -= mean;
     dev.at(3) -= mean;
     return {
-               dev, mean
+        dev, mean
     };
 }
 
 
 FloatArrayF< 6 >
-StructuralMaterial :: computeDeviator(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeDeviator(const FloatArrayF< 6 > &s)
 {
     double vol = s [ 0 ] + s [ 1 ] + s [ 2 ];
     double mean = vol / 3.0;
@@ -1447,7 +1446,7 @@ StructuralMaterial :: computeDeviator(const FloatArrayF< 6 > &s)
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: computeDeviatoricVolumetricSum(const FloatArrayF< 6 > &dev, double mean)
+StructuralMaterial::computeDeviatoricVolumetricSum(const FloatArrayF< 6 > &dev, double mean)
 {
     auto s = dev;
     s [ 0 ] += mean;
@@ -1457,94 +1456,94 @@ StructuralMaterial :: computeDeviatoricVolumetricSum(const FloatArrayF< 6 > &dev
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: applyDeviatoricElasticCompliance(const FloatArrayF< 6 > &stress, double EModulus, double nu)
+StructuralMaterial::applyDeviatoricElasticCompliance(const FloatArrayF< 6 > &stress, double EModulus, double nu)
 {
-    return applyDeviatoricElasticCompliance(stress, EModulus / 2. / ( 1. + nu ) );
+    return applyDeviatoricElasticCompliance( stress, EModulus / 2. / ( 1. + nu ) );
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: applyDeviatoricElasticCompliance(const FloatArrayF< 6 > &stress, double GModulus)
+StructuralMaterial::applyDeviatoricElasticCompliance(const FloatArrayF< 6 > &stress, double GModulus)
 {
     return {
-               1. / ( 2. * GModulus ) * stress [ 0 ],
-               1. / ( 2. * GModulus ) * stress [ 1 ],
-               1. / ( 2. * GModulus ) * stress [ 2 ],
-               1. / GModulus * stress [ 3 ],
-               1. / GModulus * stress [ 4 ],
-               1. / GModulus * stress [ 5 ],
+        1. / ( 2. * GModulus ) * stress [ 0 ],
+        1. / ( 2. * GModulus ) * stress [ 1 ],
+        1. / ( 2. * GModulus ) * stress [ 2 ],
+        1. / GModulus * stress [ 3 ],
+        1. / GModulus * stress [ 4 ],
+        1. / GModulus * stress [ 5 ],
     };
 }
 
 
 FloatArrayF< 6 >
-StructuralMaterial :: applyDeviatoricElasticStiffness(const FloatArrayF< 6 > &strain, double EModulus, double nu)
+StructuralMaterial::applyDeviatoricElasticStiffness(const FloatArrayF< 6 > &strain, double EModulus, double nu)
 {
-    return applyDeviatoricElasticStiffness(strain, EModulus / ( 2. * ( 1. + nu ) ) );
+    return applyDeviatoricElasticStiffness( strain, EModulus / ( 2. * ( 1. + nu ) ) );
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: applyDeviatoricElasticStiffness(const FloatArrayF< 6 > &strain, double GModulus)
+StructuralMaterial::applyDeviatoricElasticStiffness(const FloatArrayF< 6 > &strain, double GModulus)
 {
     return {
-               2. * GModulus * strain [ 0 ],
-               2. * GModulus * strain [ 1 ],
-               2. * GModulus * strain [ 2 ],
-               GModulus * strain [ 3 ],
-               GModulus * strain [ 4 ],
-               GModulus * strain [ 5 ],
+        2. * GModulus * strain [ 0 ],
+        2. * GModulus * strain [ 1 ],
+        2. * GModulus * strain [ 2 ],
+        GModulus *strain [ 3 ],
+        GModulus *strain [ 4 ],
+        GModulus *strain [ 5 ],
     };
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: applyElasticStiffness(const FloatArrayF< 6 > &strain, double EModulus, double nu)
+StructuralMaterial::applyElasticStiffness(const FloatArrayF< 6 > &strain, double EModulus, double nu)
 {
     double factor = EModulus / ( ( 1. + nu ) * ( 1. - 2. * nu ) );
 
     return {
-               factor * ( ( 1. - nu ) * strain [ 0 ] + nu * strain [ 1 ] + nu * strain [ 2 ] ),
-               factor * ( nu * strain [ 0 ] + ( 1. - nu ) * strain [ 1 ] + nu * strain [ 2 ] ),
-               factor * ( nu * strain [ 0 ] + nu * strain [ 1 ] + ( 1. - nu ) * strain [ 2 ] ),
-               factor * ( ( ( 1. - 2. * nu ) / 2. ) * strain [ 3 ] ),
-               factor * ( ( ( 1. - 2. * nu ) / 2. ) * strain [ 4 ] ),
-               factor * ( ( ( 1. - 2. * nu ) / 2. ) * strain [ 5 ] ),
+        factor *( ( 1. - nu ) * strain [ 0 ] + nu * strain [ 1 ] + nu * strain [ 2 ] ),
+        factor *( nu * strain [ 0 ] + ( 1. - nu ) * strain [ 1 ] + nu * strain [ 2 ] ),
+        factor *( nu * strain [ 0 ] + nu * strain [ 1 ] + ( 1. - nu ) * strain [ 2 ] ),
+        factor *( ( ( 1. - 2. * nu ) / 2. ) * strain [ 3 ] ),
+        factor *( ( ( 1. - 2. * nu ) / 2. ) * strain [ 4 ] ),
+        factor *( ( ( 1. - 2. * nu ) / 2. ) * strain [ 5 ] ),
     };
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: applyElasticCompliance(const FloatArrayF< 6 > &stress, double EModulus, double nu)
+StructuralMaterial::applyElasticCompliance(const FloatArrayF< 6 > &stress, double EModulus, double nu)
 {
     return {
-               ( stress [ 0 ] - nu * stress [ 1 ] - nu * stress [ 2 ] ) / EModulus,
-               ( -nu * stress [ 0 ] + stress [ 1 ] - nu * stress [ 2 ] ) / EModulus,
-               ( -nu * stress [ 0 ] - nu * stress [ 1 ] + stress [ 2 ] ) / EModulus,
-               ( 2. * ( 1. + nu ) * stress [ 3 ] ) / EModulus,
-               ( 2. * ( 1. + nu ) * stress [ 4 ] ) / EModulus,
-               ( 2. * ( 1. + nu ) * stress [ 5 ] ) / EModulus,
+        ( stress [ 0 ] - nu * stress [ 1 ] - nu * stress [ 2 ] ) / EModulus,
+        ( -nu * stress [ 0 ] + stress [ 1 ] - nu * stress [ 2 ] ) / EModulus,
+        ( -nu * stress [ 0 ] - nu * stress [ 1 ] + stress [ 2 ] ) / EModulus,
+        ( 2. * ( 1. + nu ) * stress [ 3 ] ) / EModulus,
+        ( 2. * ( 1. + nu ) * stress [ 4 ] ) / EModulus,
+        ( 2. * ( 1. + nu ) * stress [ 5 ] ) / EModulus,
     };
 }
 
 double
-StructuralMaterial :: computeStressNorm(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeStressNorm(const FloatArrayF< 6 > &s)
 {
     return sqrt(s [ 0 ] * s [ 0 ] + s [ 1 ] * s [ 1 ] + s [ 2 ] * s [ 2 ] +
                 2. * s [ 3 ] * s [ 3 ] + 2. * s [ 4 ] * s [ 4 ] + 2. * s [ 5 ] * s [ 5 ]);
 }
 
 double
-StructuralMaterial :: computeFirstInvariant(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeFirstInvariant(const FloatArrayF< 6 > &s)
 {
     return s [ 0 ] + s [ 1 ] + s [ 2 ];
 }
 
 double
-StructuralMaterial :: computeSecondStressInvariant(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeSecondStressInvariant(const FloatArrayF< 6 > &s)
 {
     return .5 * ( s [ 0 ] * s [ 0 ] + s [ 1 ] * s [ 1 ] + s [ 2 ] * s [ 2 ] ) +
            s [ 3 ] * s [ 3 ] + s [ 4 ] * s [ 4 ] + s [ 5 ] * s [ 5 ];
 }
 
 double
-StructuralMaterial :: computeThirdStressInvariant(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeThirdStressInvariant(const FloatArrayF< 6 > &s)
 {
     return ( 1. / 3. ) * ( s [ 0 ] * s [ 0 ] * s [ 0 ] + 3. * s [ 0 ] * s [ 5 ] * s [ 5 ] +
                            3. * s [ 0 ] * s [ 4 ] * s [ 4 ] + 6. * s [ 3 ] * s [ 5 ] * s [ 4 ] +
@@ -1555,22 +1554,22 @@ StructuralMaterial :: computeThirdStressInvariant(const FloatArrayF< 6 > &s)
 
 
 double
-StructuralMaterial :: computeFirstCoordinate(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeFirstCoordinate(const FloatArrayF< 6 > &s)
 {
     // This function computes the first Haigh-Westergaard coordinate
     return computeFirstInvariant(s) / sqrt(3.);
 }
 
 double
-StructuralMaterial :: computeSecondCoordinate(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeSecondCoordinate(const FloatArrayF< 6 > &s)
 {
     // This function computes the second Haigh-Westergaard coordinate
     // from the deviatoric stress state
-    return sqrt(2. * computeSecondStressInvariant(s) );
+    return sqrt( 2. * computeSecondStressInvariant(s) );
 }
 
 double
-StructuralMaterial :: computeThirdCoordinate(const FloatArrayF< 6 > &s)
+StructuralMaterial::computeThirdCoordinate(const FloatArrayF< 6 > &s)
 {
     // This function computes the third Haigh-Westergaard coordinate
     // from the deviatoric stress state
@@ -1578,7 +1577,7 @@ StructuralMaterial :: computeThirdCoordinate(const FloatArrayF< 6 > &s)
     if ( computeSecondStressInvariant(s) == 0. ) {
         c1 = 0.0;
     } else {
-        c1 = ( 3. * sqrt(3.) / 2. ) * computeThirdStressInvariant(s) / ( pow(computeSecondStressInvariant(s), ( 3. / 2. ) ) );
+        c1 = ( 3. * sqrt(3.) / 2. ) * computeThirdStressInvariant(s) / ( pow( computeSecondStressInvariant(s), ( 3. / 2. ) ) );
     }
 
     if ( c1 > 1.0 ) {
@@ -1594,7 +1593,7 @@ StructuralMaterial :: computeThirdCoordinate(const FloatArrayF< 6 > &s)
 
 
 double
-StructuralMaterial :: computeVonMisesStress(const FloatArray &stress)
+StructuralMaterial::computeVonMisesStress(const FloatArray &stress)
 {
     if ( stress.giveSize() == 3 ) {
         return computeVonMisesStress_PlaneStress(stress);
@@ -1616,15 +1615,15 @@ StructuralMaterial :: computeVonMisesStress(const FloatArray &stress)
 
 
 double
-StructuralMaterial :: computeVonMisesStress_PlaneStress(const FloatArrayF< 3 > &stress)
+StructuralMaterial::computeVonMisesStress_PlaneStress(const FloatArrayF< 3 > &stress)
 {
-    return sqrt(stress.at(1) * stress.at(1) + stress.at(2) * stress.at(2)
-                - stress.at(1) * stress.at(2) + 3 * stress.at(3) * stress.at(3) );
+    return sqrt( stress.at(1) * stress.at(1) + stress.at(2) * stress.at(2)
+                 - stress.at(1) * stress.at(2) + 3 * stress.at(3) * stress.at(3) );
 }
 
 
 double
-StructuralMaterial :: computeVonMisesStress_3D(const FloatArrayF< 6 > &stress)
+StructuralMaterial::computeVonMisesStress_3D(const FloatArrayF< 6 > &stress)
 {
     double v1 = ( ( stress.at(1) - stress.at(2) ) * ( stress.at(1) - stress.at(2) ) );
     double v2 = ( ( stress.at(2) - stress.at(3) ) * ( stress.at(2) - stress.at(3) ) );
@@ -1639,8 +1638,8 @@ StructuralMaterial :: computeVonMisesStress_3D(const FloatArrayF< 6 > &stress)
 
 
 FloatMatrixF< 6, 6 >
-StructuralMaterial :: giveStrainVectorTranformationMtrx(const FloatMatrixF< 3, 3 > &base,
-                                                        bool trans)
+StructuralMaterial::giveStrainVectorTranformationMtrx(const FloatMatrixF< 3, 3 > &base,
+                                                      bool trans)
 //
 // returns transformation matrix for 3d - strains to another system of axes,
 // given by base.
@@ -1700,8 +1699,8 @@ StructuralMaterial :: giveStrainVectorTranformationMtrx(const FloatMatrixF< 3, 3
 
 
 FloatMatrixF< 3, 3 >
-StructuralMaterial :: give2DStrainVectorTranformationMtrx(const FloatMatrixF< 2, 2 > &base,
-                                                          bool trans)
+StructuralMaterial::give2DStrainVectorTranformationMtrx(const FloatMatrixF< 2, 2 > &base,
+                                                        bool trans)
 //
 // returns transformation matrix for 2d - strains to another system of axes,
 // given by base.
@@ -1729,8 +1728,8 @@ StructuralMaterial :: give2DStrainVectorTranformationMtrx(const FloatMatrixF< 2,
 
 
 FloatMatrixF< 6, 6 >
-StructuralMaterial :: giveStressVectorTranformationMtrx(const FloatMatrixF< 3, 3 > &base,
-                                                        bool trans)
+StructuralMaterial::giveStressVectorTranformationMtrx(const FloatMatrixF< 3, 3 > &base,
+                                                      bool trans)
 //
 // returns transformation matrix for 3d - stress to another system of axes,
 // given by base.
@@ -1790,8 +1789,8 @@ StructuralMaterial :: giveStressVectorTranformationMtrx(const FloatMatrixF< 3, 3
 
 
 FloatMatrixF< 3, 3 >
-StructuralMaterial :: givePlaneStressVectorTranformationMtrx(const FloatMatrixF< 2, 2 > &base,
-                                                             bool trans)
+StructuralMaterial::givePlaneStressVectorTranformationMtrx(const FloatMatrixF< 2, 2 > &base,
+                                                           bool trans)
 //
 // returns transformation matrix for 2d - stress to another system of axes,
 // given by base.
@@ -1820,8 +1819,8 @@ StructuralMaterial :: givePlaneStressVectorTranformationMtrx(const FloatMatrixF<
 
 
 FloatArrayF< 6 >
-StructuralMaterial :: transformStrainVectorTo(const FloatMatrixF< 3, 3 > &base,
-                                              const FloatArrayF< 6 > &strain, bool transpose)
+StructuralMaterial::transformStrainVectorTo(const FloatMatrixF< 3, 3 > &base,
+                                            const FloatArrayF< 6 > &strain, bool transpose)
 //
 // performs transformation of 3d-strain vector to another system of axes,
 // given by base.
@@ -1831,14 +1830,14 @@ StructuralMaterial :: transformStrainVectorTo(const FloatMatrixF< 3, 3 > &base,
 //
 // If transpose == 1 we transpose base matrix before transforming
 {
-    auto tt = StructuralMaterial :: giveStrainVectorTranformationMtrx(base, transpose);
+    auto tt = StructuralMaterial::giveStrainVectorTranformationMtrx(base, transpose);
     return dot(tt, strain);
 }
 
 
 FloatArrayF< 6 >
-StructuralMaterial :: transformStressVectorTo(const FloatMatrixF< 3, 3 > &base,
-                                              const FloatArrayF< 6 > &stress, bool transpose)
+StructuralMaterial::transformStressVectorTo(const FloatMatrixF< 3, 3 > &base,
+                                            const FloatArrayF< 6 > &stress, bool transpose)
 //
 //
 // performs transformation of 3d-stress vector to another system of axes,
@@ -1849,14 +1848,14 @@ StructuralMaterial :: transformStressVectorTo(const FloatMatrixF< 3, 3 > &base,
 // If transpose == 1 we transpose base matrix before transforming
 //
 {
-    auto tt = StructuralMaterial :: giveStressVectorTranformationMtrx(base, transpose);
+    auto tt = StructuralMaterial::giveStressVectorTranformationMtrx(base, transpose);
     return dot(tt, stress);
 }
 
 
 void
-StructuralMaterial :: sortPrincDirAndValCloseTo(FloatArray &pVal, FloatMatrix &pDir,
-                                                const FloatMatrix &toPDir)
+StructuralMaterial::sortPrincDirAndValCloseTo(FloatArray &pVal, FloatMatrix &pDir,
+                                              const FloatMatrix &toPDir)
 //
 // this method sorts newly computed principal values (pVal) and
 // corresponding principal directions (pDir) to be closed to
@@ -1905,7 +1904,7 @@ StructuralMaterial :: sortPrincDirAndValCloseTo(FloatArray &pVal, FloatMatrix &p
 
 
 int
-StructuralMaterial :: setIPValue(const FloatArray &value, GaussPoint *gp, InternalStateType type)
+StructuralMaterial::setIPValue(const FloatArray &value, GaussPoint *gp, InternalStateType type)
 {
     StructuralMaterialStatus *status = static_cast< StructuralMaterialStatus * >( this->giveStatus(gp) );
     if ( type == IST_StressTensor ) {
@@ -1927,11 +1926,11 @@ StructuralMaterial :: setIPValue(const FloatArray &value, GaussPoint *gp, Intern
 
 
 int
-StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalStateType type, TimeStep *tStep)
+StructuralMaterial::giveIPValue(FloatArray &answer, GaussPoint *gp, InternalStateType type, TimeStep *tStep)
 {
     StructuralMaterialStatus *status = static_cast< StructuralMaterialStatus * >( this->giveStatus(gp) );
     if ( type == IST_StressTensor ) {
-        StructuralMaterial :: giveFullSymVectorForm(answer, status->giveStressVector(), gp->giveMaterialMode() );
+        StructuralMaterial::giveFullSymVectorForm( answer, status->giveStressVector(), gp->giveMaterialMode() );
         return 1;
     } else if ( type == IST_StressTensor_Reduced ) {
         answer = status->giveStressVector();
@@ -1940,14 +1939,14 @@ StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalSt
         ///@todo What about the stress meassure in large deformations here? The internal state type should specify "Cauchy" or something.
         answer.resize(1);
         if ( status->giveStressVector().giveSize() == 6 ) {
-            answer.at(1) = this->computeVonMisesStress_3D(status->giveStressVector() );
+            answer.at(1) = this->computeVonMisesStress_3D( status->giveStressVector() );
         } else {
-            answer.at(1) = this->computeVonMisesStress(status->giveStressVector() );
+            answer.at(1) = this->computeVonMisesStress( status->giveStressVector() );
         }
         return 1;
     } else if ( type == IST_StrainTensor ) {
         ///@todo Fill in correct full form values here! This just adds zeros!
-        StructuralMaterial :: giveFullSymVectorForm(answer, status->giveStrainVector(), gp->giveMaterialMode() );
+        StructuralMaterial::giveFullSymVectorForm( answer, status->giveStrainVector(), gp->giveMaterialMode() );
         /* commented out by Milan - this evaluation of the out-of-plane strain would be correct for elastic material only
          *                          and for other materials can lead to misleading values
          * if ( gp->giveMaterialMode() == _PlaneStress) {
@@ -1965,21 +1964,21 @@ StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalSt
         return 1;
     } else if ( type == IST_StressTensorTemp ) {
         ///@todo Fill in correct full form values here! This just adds zeros!
-        StructuralMaterial :: giveFullSymVectorForm(answer, status->giveTempStressVector(), gp->giveMaterialMode() );
+        StructuralMaterial::giveFullSymVectorForm( answer, status->giveTempStressVector(), gp->giveMaterialMode() );
         return 1;
     } else if ( type == IST_StrainTensorTemp ) {
         ///@todo Fill in correct full form values here! This just adds zeros!
-        StructuralMaterial :: giveFullSymVectorForm(answer, status->giveTempStrainVector(), gp->giveMaterialMode() );
+        StructuralMaterial::giveFullSymVectorForm( answer, status->giveTempStrainVector(), gp->giveMaterialMode() );
         return 1;
     } else if ( type == IST_PrincipalStressTensor || type == IST_PrincipalStressTempTensor ) {
         FloatArray s;
 
         if ( type == IST_PrincipalStressTensor ) {
             ///@todo Fill in correct full form values here! This just adds zeros!
-            StructuralMaterial :: giveFullSymVectorForm(s, status->giveStressVector(), gp->giveMaterialMode() );
+            StructuralMaterial::giveFullSymVectorForm( s, status->giveStressVector(), gp->giveMaterialMode() );
         } else {
             ///@todo Fill in correct full form values here! This just adds zeros!
-            StructuralMaterial :: giveFullSymVectorForm(s, status->giveTempStressVector(), gp->giveMaterialMode() );
+            StructuralMaterial::giveFullSymVectorForm( s, status->giveTempStressVector(), gp->giveMaterialMode() );
         }
 
         this->computePrincipalValues(answer, s, principal_stress);
@@ -1989,10 +1988,10 @@ StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalSt
 
         if ( type == IST_PrincipalStrainTensor ) {
             ///@todo Fill in correct full form values here! This just adds zeros!
-            StructuralMaterial :: giveFullSymVectorForm(s, status->giveStrainVector(), gp->giveMaterialMode() );
+            StructuralMaterial::giveFullSymVectorForm( s, status->giveStrainVector(), gp->giveMaterialMode() );
         } else {
             ///@todo Fill in correct full form values here! This just adds zeros!
-            StructuralMaterial :: giveFullSymVectorForm(s, status->giveTempStrainVector(), gp->giveMaterialMode() );
+            StructuralMaterial::giveFullSymVectorForm( s, status->giveTempStrainVector(), gp->giveMaterialMode() );
         }
 
         this->computePrincipalValues(answer, s, principal_strain);
@@ -2027,7 +2026,7 @@ StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalSt
         if ( ( tf = fm->giveField(FT_Temperature) ) ) {
             // temperature field registered
             FloatArray gcoords, et2;
-            static_cast< StructuralElement * >( gp->giveElement() )->computeGlobalCoordinates(gcoords, gp->giveNaturalCoordinates() );
+            static_cast< StructuralElement * >( gp->giveElement() )->computeGlobalCoordinates( gcoords, gp->giveNaturalCoordinates() );
             if ( ( err = tf->evaluateAt(answer, gcoords, VM_Total, tStep) ) ) {
                 OOFEM_ERROR("tf->evaluateAt failed, element %d, error code %d", gp->giveElement()->giveNumber(), err);
             }
@@ -2040,8 +2039,8 @@ StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalSt
     } else if ( type == IST_CylindricalStressTensor || type == IST_CylindricalStrainTensor ) {
         FloatArray gc, val = status->giveStressVector();
         FloatMatrix base(3, 3);
-        static_cast< StructuralElement * >( gp->giveElement() )->computeGlobalCoordinates(gc, gp->giveNaturalCoordinates() );
-        double l = sqrt(gc.at(1) * gc.at(1) + gc.at(2) * gc.at(2) );
+        static_cast< StructuralElement * >( gp->giveElement() )->computeGlobalCoordinates( gc, gp->giveNaturalCoordinates() );
+        double l = sqrt( gc.at(1) * gc.at(1) + gc.at(2) * gc.at(2) );
         if ( l > 1.e-4 ) {
             base.at(1, 1) = gc.at(1) / l;
             base.at(2, 1) = gc.at(2) / l;
@@ -2066,7 +2065,7 @@ StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalSt
 
         return 1;
     } else if ( type == IST_PlasticStrainTensor ) {
-        StructuralMaterial :: giveFullSymVectorForm(answer, status->giveStrainVector(), gp->giveMaterialMode() );
+        StructuralMaterial::giveFullSymVectorForm( answer, status->giveStrainVector(), gp->giveMaterialMode() );
         answer.zero();
         return 1;
     } else if ( type == IST_MaxEquivalentStrainLevel ) {
@@ -2083,19 +2082,19 @@ StructuralMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, InternalSt
         FloatArray eigenstrain;
         StructuralElement *selem = dynamic_cast< StructuralElement * >( gp->giveElement() );
         selem->computeResultingIPEigenstrainAt(eigenstrain, tStep, gp, VM_Total);
-        StructuralMaterial :: giveFullSymVectorForm(answer, eigenstrain, gp->giveMaterialMode() );
+        StructuralMaterial::giveFullSymVectorForm( answer, eigenstrain, gp->giveMaterialMode() );
         return 1;
     } else if ( type == IST_ShellForceTensor ) {
         answer.resize(6);
         answer.zero();
         return 1;
     } else {
-        return Material :: giveIPValue(answer, gp, type, tStep);
+        return Material::giveIPValue(answer, gp, type, tStep);
     }
 }
 
 FloatArray
-StructuralMaterial :: computeStressIndependentStrainVector(GaussPoint *gp, TimeStep *tStep, ValueModeType mode) const
+StructuralMaterial::computeStressIndependentStrainVector(GaussPoint *gp, TimeStep *tStep, ValueModeType mode) const
 {
     FloatArray et, eigenstrain;
     if ( gp->giveIntegrationRule() == NULL ) {
@@ -2121,8 +2120,8 @@ StructuralMaterial :: computeStressIndependentStrainVector(GaussPoint *gp, TimeS
         selem->computeResultingIPEigenstrainAt(eigenstrain, tStep, gp, mode);
     }
 
-    if ( eigenstrain.giveSize() != 0 && eigenstrain.giveSize() != giveSizeOfVoigtSymVector(gp->giveMaterialMode() ) ) {
-        OOFEM_ERROR("Number of given eigenstrain components %d is different than required %d by element %d", eigenstrain.giveSize(), giveSizeOfVoigtSymVector(gp->giveMaterialMode() ), elem->giveNumber() );
+    if ( eigenstrain.giveSize() != 0 && eigenstrain.giveSize() != giveSizeOfVoigtSymVector( gp->giveMaterialMode() ) ) {
+        OOFEM_ERROR( "Number of given eigenstrain components %d is different than required %d by element %d", eigenstrain.giveSize(), giveSizeOfVoigtSymVector( gp->giveMaterialMode() ), elem->giveNumber() );
     }
 
     /* add external source, if provided */
@@ -2133,7 +2132,7 @@ StructuralMaterial :: computeStressIndependentStrainVector(GaussPoint *gp, TimeS
         // temperature field registered
         FloatArray gcoords, et2;
         int err;
-        elem->computeGlobalCoordinates(gcoords, gp->giveNaturalCoordinates() );
+        elem->computeGlobalCoordinates( gcoords, gp->giveNaturalCoordinates() );
         if ( ( err = tf->evaluateAt(et2, gcoords, mode, tStep) ) ) {
             OOFEM_ERROR("tf->evaluateAt failed, element %d, error code %d", elem->giveNumber(), err);
         }
@@ -2153,7 +2152,7 @@ StructuralMaterial :: computeStressIndependentStrainVector(GaussPoint *gp, TimeS
 
         double scale = mode == VM_Total ? ( et.at(1) - this->referenceTemperature ) : et.at(1);
         FloatArray fullAnswer = e0 * scale;
-        StructuralMaterial :: giveReducedSymVectorForm(answer, fullAnswer, gp->giveMaterialMode() );
+        StructuralMaterial::giveReducedSymVectorForm( answer, fullAnswer, gp->giveMaterialMode() );
         //answer = fullAnswer;
     }
 
@@ -2161,7 +2160,7 @@ StructuralMaterial :: computeStressIndependentStrainVector(GaussPoint *gp, TimeS
     if ( answer.giveSize() ) {
         if ( eigenstrain.giveSize() ) {
             if ( answer.giveSize() != eigenstrain.giveSize() ) {
-                OOFEM_ERROR("Vector of temperature strains has the size %d which is different with the size of eigenstrain vector %d, element %d", answer.giveSize(), eigenstrain.giveSize(), elem->giveNumber() );
+                OOFEM_ERROR( "Vector of temperature strains has the size %d which is different with the size of eigenstrain vector %d, element %d", answer.giveSize(), eigenstrain.giveSize(), elem->giveNumber() );
             }
 
             answer.add(eigenstrain);
@@ -2176,7 +2175,7 @@ StructuralMaterial :: computeStressIndependentStrainVector(GaussPoint *gp, TimeS
 
 
 FloatArrayF< 6 >
-StructuralMaterial :: computeStressIndependentStrainVector_3d(GaussPoint *gp, TimeStep *tStep, ValueModeType mode) const
+StructuralMaterial::computeStressIndependentStrainVector_3d(GaussPoint *gp, TimeStep *tStep, ValueModeType mode) const
 {
     if ( gp->giveIntegrationRule() == NULL ) {
         ///@todo Hack for loose gausspoints. We shouldn't ask for "gp->giveElement()". FIXME
@@ -2207,7 +2206,7 @@ StructuralMaterial :: computeStressIndependentStrainVector_3d(GaussPoint *gp, Ti
     if ( tf ) {
         // temperature field registered
         FloatArray gcoords, et2;
-        elem->computeGlobalCoordinates(gcoords, gp->giveNaturalCoordinates() );
+        elem->computeGlobalCoordinates( gcoords, gp->giveNaturalCoordinates() );
         int err;
         if ( ( err = tf->evaluateAt(et2, gcoords, mode, tStep) ) ) {
             OOFEM_ERROR("tf->evaluateAt failed, element %d, error code %d", elem->giveNumber(), err);
@@ -2237,14 +2236,14 @@ StructuralMaterial :: computeStressIndependentStrainVector_3d(GaussPoint *gp, Ti
 
 
 void
-StructuralMaterial :: giveFullSymVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
+StructuralMaterial::giveFullSymVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
 {
     if ( vec.giveSize() == 6 ) {
         // If we use default 3D implementation to treat e.g. plane strain.
         answer = vec;
     } else {
         IntArray indx;
-        answer.resize(StructuralMaterial :: giveVoigtSymVectorMask(indx, matMode) );
+        answer.resize( StructuralMaterial::giveVoigtSymVectorMask(indx, matMode) );
         answer.zero();
         answer.assemble(vec, indx);
     }
@@ -2252,54 +2251,53 @@ StructuralMaterial :: giveFullSymVectorForm(FloatArray &answer, const FloatArray
 
 
 void
-StructuralMaterial :: giveFullVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
+StructuralMaterial::giveFullVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
 {
-
-  if ( vec.giveSize() == 9 ) {
-    // If we use default 3D implementation to treat e.g. plane strain.
-    answer = vec;
-  } else {
-    IntArray indx;
-    answer.resize(StructuralMaterial :: giveVoigtVectorMask(indx, matMode) );
-    answer.zero();
-    answer.assemble(vec, indx);
-  }
-}
-
-
-void
-StructuralMaterial :: giveFullVectorFormF(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
-{
-  if ( vec.giveSize() == 9 ) {
-    // If we use default 3D implementation to treat e.g. plane strain.
-    answer = vec;
-  } else {
-    IntArray indx;
-    answer.resize(9);
-    answer.at(1) = answer.at(2) = answer.at(3) = 1.0;   // set diagonal terms
-    
-    StructuralMaterial :: giveVoigtVectorMask(indx, matMode);
-    for ( int i = 1; i <= indx.giveSize(); i++ ) {
-      answer.at(indx.at(i) ) = vec.at(i);
+    if ( vec.giveSize() == 9 ) {
+        // If we use default 3D implementation to treat e.g. plane strain.
+        answer = vec;
+    } else {
+        IntArray indx;
+        answer.resize( StructuralMaterial::giveVoigtVectorMask(indx, matMode) );
+        answer.zero();
+        answer.assemble(vec, indx);
     }
-  }
 }
 
 
 void
-StructuralMaterial :: giveReducedVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
+StructuralMaterial::giveFullVectorFormF(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
+{
+    if ( vec.giveSize() == 9 ) {
+        // If we use default 3D implementation to treat e.g. plane strain.
+        answer = vec;
+    } else {
+        IntArray indx;
+        answer.resize(9);
+        answer.at(1) = answer.at(2) = answer.at(3) = 1.0; // set diagonal terms
+
+        StructuralMaterial::giveVoigtVectorMask(indx, matMode);
+        for ( int i = 1; i <= indx.giveSize(); i++ ) {
+            answer.at( indx.at(i) ) = vec.at(i);
+        }
+    }
+}
+
+
+void
+StructuralMaterial::giveReducedVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
 {
     IntArray indx;
-    StructuralMaterial :: giveVoigtVectorMask(indx, matMode);
+    StructuralMaterial::giveVoigtVectorMask(indx, matMode);
     answer.beSubArrayOf(vec, indx);
 }
 
 
 void
-StructuralMaterial :: giveReducedSymVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
+StructuralMaterial::giveReducedSymVectorForm(FloatArray &answer, const FloatArray &vec, MaterialMode matMode)
 {
     IntArray indx;
-    StructuralMaterial :: giveVoigtSymVectorMask(indx, matMode);
+    StructuralMaterial::giveVoigtSymVectorMask(indx, matMode);
 
     if ( indx.giveSize() == vec.giveSize() ) {
         answer = vec;
@@ -2310,10 +2308,10 @@ StructuralMaterial :: giveReducedSymVectorForm(FloatArray &answer, const FloatAr
 
 
 void
-StructuralMaterial :: giveFullSymMatrixForm(FloatMatrix &answer, const FloatMatrix &red, MaterialMode matMode)
+StructuralMaterial::giveFullSymMatrixForm(FloatMatrix &answer, const FloatMatrix &red, MaterialMode matMode)
 {
     IntArray indx;
-    int size = StructuralMaterial :: giveVoigtSymVectorMask(indx, matMode);
+    int size = StructuralMaterial::giveVoigtSymVectorMask(indx, matMode);
     answer.resize(size, size);
     answer.zero();
     answer.assemble(red, indx, indx);
@@ -2321,40 +2319,40 @@ StructuralMaterial :: giveFullSymMatrixForm(FloatMatrix &answer, const FloatMatr
 
 
 void
-StructuralMaterial :: giveReducedMatrixForm(FloatMatrix &answer, const FloatMatrix &full, MaterialMode matMode)
+StructuralMaterial::giveReducedMatrixForm(FloatMatrix &answer, const FloatMatrix &full, MaterialMode matMode)
 {
     IntArray indx;
-    StructuralMaterial :: giveVoigtVectorMask(indx, matMode);
+    StructuralMaterial::giveVoigtVectorMask(indx, matMode);
     answer.beSubMatrixOf(full, indx, indx);
 }
 
 
 void
-StructuralMaterial :: giveReducedSymMatrixForm(FloatMatrix &answer, const FloatMatrix &full, MaterialMode matMode)
+StructuralMaterial::giveReducedSymMatrixForm(FloatMatrix &answer, const FloatMatrix &full, MaterialMode matMode)
 {
     IntArray indx;
-    StructuralMaterial :: giveVoigtSymVectorMask(indx, matMode);
+    StructuralMaterial::giveVoigtSymVectorMask(indx, matMode);
     answer.beSubMatrixOf(full, indx, indx);
 }
 
 FloatArrayF< 6 >
-StructuralMaterial :: giveThermalDilatationVector(GaussPoint *gp, TimeStep *tStep) const
+StructuralMaterial::giveThermalDilatationVector(GaussPoint *gp, TimeStep *tStep) const
 {
     double alpha = this->give(tAlpha, gp);
     return {
-               alpha,
-               alpha,
-               alpha,
-               0.,
-               0.,
-               0.,
+        alpha,
+        alpha,
+        alpha,
+        0.,
+        0.,
+        0.,
     };
 }
 
 void
-StructuralMaterial :: initializeFrom(InputRecord &ir)
+StructuralMaterial::initializeFrom(InputRecord &ir)
 {
-    Material :: initializeFrom(ir);
+    Material::initializeFrom(ir);
 
     referenceTemperature = 0.0;
     IR_GIVE_OPTIONAL_FIELD(ir, referenceTemperature, _IFT_StructuralMaterial_referencetemperature);
@@ -2371,9 +2369,9 @@ StructuralMaterial :: initializeFrom(InputRecord &ir)
 
 
 void
-StructuralMaterial :: giveInputRecord(DynamicInputRecord &input)
+StructuralMaterial::giveInputRecord(DynamicInputRecord &input)
 {
-    Material :: giveInputRecord(input);
+    Material::giveInputRecord(input);
     input.setField(this->referenceTemperature, _IFT_StructuralMaterial_referencetemperature);
 }
 } // end namespace oofem


### PR DESCRIPTION
- Rewrote treatment of return results in concretedpm2 and lattice material models latticeplasticitydamage and latticebondplasticity so that it is thread safe and return results are not unnecessary stored in status.
- Increased number of iterations and tolerance in StressControl in structuralmaterial so that 1D cdpm2 analyses converge.