### PR TITLE
Python Bindings on Windows VS2019+

### DIFF
--- a/bindings/python/oofem.cpp
+++ b/bindings/python/oofem.cpp
@@ -118,6 +118,7 @@ void test (oofem::Element& e) {
     Trampoline classes
 */
 template <class FemComponentBase = oofem::FEMComponent> class PyFemComponent : public FemComponentBase {
+public:
     using FemComponentBase::FemComponentBase;
 };
 

--- a/src/oofemlib/assemblercallback.h
+++ b/src/oofemlib/assemblercallback.h
@@ -35,6 +35,7 @@
 #ifndef assemblercallback_h
 #define assemblercallback_h
 
+#include "oofem_export.h"
 #include "valuemodetype.h" ///@todo We shouldn't have this for assembling vectors or matrices(!) / Mikael
 #include "matresponsemode.h"
 #include "chartype.h"
@@ -60,7 +61,7 @@ class ActiveBoundaryCondition;
  * Default implementations are that no contributions are considered (empty vectors on output).
  * @author Mikael Öhman
  */
-class VectorAssembler
+class OOFEM_EXPORT VectorAssembler
 {
 public:
     virtual void vectorFromElement(FloatArray &vec, Element &element, TimeStep *tStep, ValueModeType mode) const;
@@ -80,7 +81,7 @@ public:
  * Callback class for assembling specific types of matrices
  * @author Mikael Öhman
  */
-class MatrixAssembler
+class OOFEM_EXPORT MatrixAssembler
 {
 public:
     virtual void matrixFromElement(FloatMatrix &mat, Element &element, TimeStep *tStep) const;
@@ -98,7 +99,7 @@ public:
  * Implementation for assembling internal forces vectors in standard monolithic, nonlinear FE-problems
  * @author Mikael Öhman
  */
-class InternalForceAssembler : public VectorAssembler
+class OOFEM_EXPORT InternalForceAssembler : public VectorAssembler
 {
 public:
     void vectorFromElement(FloatArray &vec, Element &element, TimeStep *tStep, ValueModeType mode) const override;
@@ -112,7 +113,7 @@ public:
  * Implementation for assembling external forces vectors in standard monolithic FE-problems
  * @author Mikael Öhman
  */
-class ExternalForceAssembler : public VectorAssembler
+class OOFEM_EXPORT ExternalForceAssembler : public VectorAssembler
 {
 public:
     void vectorFromElement(FloatArray &vec, Element &element, TimeStep *tStep, ValueModeType mode) const override; ///@todo Temporary: Remove when switch to sets is complete
@@ -127,7 +128,7 @@ public:
  * Implementation for assembling reference (external) forces vectors
  * @author Mikael Öhman
  */
-class ReferenceForceAssembler : public VectorAssembler
+class OOFEM_EXPORT ReferenceForceAssembler : public VectorAssembler
 {
 public:
     void vectorFromLoad(FloatArray &vec, Element &element, BodyLoad *load, TimeStep *tStep, ValueModeType mode) const override;
@@ -140,7 +141,7 @@ public:
  * Implementation for assembling lumped mass matrix (diagonal components) in vector form.
  * @author Mikael Öhman
  */
-class LumpedMassVectorAssembler : public VectorAssembler
+class OOFEM_EXPORT LumpedMassVectorAssembler : public VectorAssembler
 {
 public:
     void vectorFromElement(FloatArray &vec, Element &element, TimeStep *tStep, ValueModeType mode) const override;
@@ -150,7 +151,7 @@ public:
  * Implementation for assembling the intertia forces vector (i.e. C * dT/dt or M * a)
  * @author Mikael Öhman
  */
-class InertiaForceAssembler : public VectorAssembler
+class OOFEM_EXPORT InertiaForceAssembler : public VectorAssembler
 {
 public:
     void vectorFromElement(FloatArray &vec, Element &element, TimeStep *tStep, ValueModeType mode) const override;
@@ -162,7 +163,7 @@ public:
  * This is useful for computing; f = K * u for extrapolated forces, without constructing the K-matrix.
  * @author Mikael Öhman
  */
-class MatrixProductAssembler : public VectorAssembler
+class OOFEM_EXPORT MatrixProductAssembler : public VectorAssembler
 {
 protected:
     const MatrixAssembler &mAssem;
@@ -181,7 +182,7 @@ public:
  * Implementation for assembling tangent matrices in standard monolithic FE-problems
  * @author Mikael Öhman
  */
-class TangentAssembler : public MatrixAssembler
+class OOFEM_EXPORT TangentAssembler : public MatrixAssembler
 {
 protected:
     ///@todo This is more general than just material responses; we should make a "TangentType"
@@ -202,7 +203,7 @@ public:
  * Implementation for assembling the consistent mass matrix
  * @author Mikael Öhman
  */
-class MassMatrixAssembler : public MatrixAssembler
+class OOFEM_EXPORT MassMatrixAssembler : public MatrixAssembler
 {
 public:
     void matrixFromElement(FloatMatrix &mat, Element &element, TimeStep *tStep) const override;
@@ -213,7 +214,7 @@ public:
  * Callback class for assembling effective tangents composed of stiffness and mass matrix.
  * @author Mikael Öhman
  */
-class EffectiveTangentAssembler : public MatrixAssembler
+class OOFEM_EXPORT EffectiveTangentAssembler : public MatrixAssembler
 {
 protected:
     MatResponseMode rmode;


### PR DESCRIPTION
# PR description

This PR facilitates the compilation of oofempy on Windows using VS2019+

# PR changes

The changes on the codebase are limited and quite straightforward.

They mostly involve the addition of the export macro for matrix and vector assemblers.

Pybind is bumped to version 2.9.1 which drops support to old Python 2.7 and 3.5.

Note: It should still be possible to use version 2.9.0 as it's the first to fix a compatibility problem with the recent VC toolchains.

# How to build oofempy on Windows, VS2019+, Python 3.6+

## Prerequisite - Python debug symbols and binaries must NOT be installed.

Note: https://github.com/pybind/pybind11/issues/3403

1. Open Control Panel -> Programs -> Programs and Features
2. Look for your Python 3 installation. Click it. On the bar above choose "Change"

![image](https://user-images.githubusercontent.com/13045293/175651573-c7a7f712-0a3d-4d5a-8fd8-96169810a872.png)

3. In the setup form, choose "Modify"

![image](https://user-images.githubusercontent.com/13045293/175652777-67a338e0-6f91-453f-b534-fa264ff50435.png)

4. Press "Next" until you reach the screen with the option to download debug symbols and binaries.
- If they're unchecked you can cancel the setup.
- Otherwise, uncheck them both and then press the "Install" button to apply the changes.

![image](https://user-images.githubusercontent.com/13045293/175658228-84a1276a-409c-47e8-ad26-19997cd00938.png)

## Setup your CMake

1. Activate `USE_PYBIND_BINDINGS`
2. It is recommended to also activate `PYBIND11_FINDPYTHON` to let CMake find the Python installation on your system.

## Problems with Windows and its case insensitive file names

Context:
- Oofem repository contains a `VERSION` file
- Pybind's include chain reaches a point where the statement `#include <version>` appears, which includes the `version` file from the MSVC standard library.
- MSVC standard library includes are picked up by the compiler through the `INCLUDE` environment variable.

This is not a problem when the filesystem is case sensitive. Windows, however, is case insensitive and, given [how the compiler looks for include directories](https://docs.microsoft.com/en-us/cpp/build/reference/i-additional-include-directories?view=msvc-170), it means that `VERSION` file is preferred over `version` thus breaking the compilation.

In order to overcome this issue, two solutions are possible:

1. Temporarily remove/rename the VERSION file in oofem's repository. Remember not to commit this change!
2. Let the MSVC include paths be the first to be searched by the compiler. Add `/I "$(VC_IncludePath)"` to the compiler flags in your CMake configuration:

![image](https://user-images.githubusercontent.com/13045293/175659920-a72dafc1-a651-4a97-b193-8313659f452a.png)
