### PR TITLE
Fixing a bug in VTKXMLPeriodicExportModule

### DIFF
--- a/src/oofemlib/dofiditem.h
+++ b/src/oofemlib/dofiditem.h
@@ -81,11 +81,11 @@ namespace oofem {
 	ENUM_ITEM_WITH_VALUE(E_yy, 32) /* Macroscopic strain component yy*/ \
 	ENUM_ITEM_WITH_VALUE(E_zz, 33) /* Macroscopic strain component zz*/ \
 	ENUM_ITEM_WITH_VALUE(E_yz, 34) /* Macroscopic strain component yz*/ \
-	ENUM_ITEM_WITH_VALUE(E_zy, 35) /* Macroscopic strain component yz*/ \
+	ENUM_ITEM_WITH_VALUE(E_zy, 35) /* Macroscopic strain component zy*/ \
   	ENUM_ITEM_WITH_VALUE(E_xz, 36) /* Macroscopic strain component xz*/ \
-        ENUM_ITEM_WITH_VALUE(E_zx, 37) /* Macroscopic strain component xz*/ \
+        ENUM_ITEM_WITH_VALUE(E_zx, 37) /* Macroscopic strain component zx*/ \
 	ENUM_ITEM_WITH_VALUE(E_xy, 38) /* Macroscopic strain component xy*/ \
-      	ENUM_ITEM_WITH_VALUE(E_yx, 39) /* Macroscopic strain component xy*/ \
+      	ENUM_ITEM_WITH_VALUE(E_yx, 39) /* Macroscopic strain component yx*/ \
  \
 	ENUM_ITEM_WITH_VALUE(G_yz, 40) /* Macroscopic shear strain component xy (E_yz+E_zy)*/ \
       	ENUM_ITEM_WITH_VALUE(G_xz, 41) /* Macroscopic shear strain component xz (E_xz+E_zx)*/ \

--- a/src/oofemlib/vtkxmlperiodicexportmodule.C
+++ b/src/oofemlib/vtkxmlperiodicexportmodule.C
@@ -422,14 +422,13 @@ VTKXMLPeriodicExportModule :: initRegionNodeNumbering(VTKPiece& vtkPiece,
         }
     }
 
-
-    vtkPiece.setNumberOfNodes(regionDofMans);   
-    vtkPiece.setNumberOfCells(regionSingleCells);
- 
     uniqueNodeTable.resizeWithData(nnodes + uniqueNodes, 3);
     regionDofMans = nnodes + uniqueNodes;
     regionG2LNodalNumbers.resizeWithValues(regionDofMans);
     regionL2GNodalNumbers.resize(regionDofMans);
+
+    vtkPiece.setNumberOfNodes(regionDofMans);
+    vtkPiece.setNumberOfCells(regionSingleCells);
 
     for ( int i = 1; i <= regionDofMans; i++ ) {
         if ( regionG2LNodalNumbers.at(i) ) {


### PR DESCRIPTION
This pull request fixes a bug in vtkxmlperiodic export module, in which the number of nodes and cells for the vtkPiece was set too soon. As a result, the vtkxml export in examples ltrspaceboundary01-06 was not working properly. Also, some notation typos in dofiditem.h have been corrected.