### PR TITLE
Beam3d ghost node initialization

### DIFF
--- a/src/sm/Elements/Beams/beam3d.C
+++ b/src/sm/Elements/Beams/beam3d.C
@@ -584,7 +584,7 @@ Beam3d :: initializeFrom(InputRecord &ir)
                 ghostNodes [ 0 ]->appendDof( new MasterDof(ghostNodes [ 0 ], mask [ val.at(i) - 1 ]) );
             } else {
                 if ( ghostNodes [ 1 ] == NULL ) {
-                    ghostNodes [ 1 ] = new ElementDofManager(1, giveDomain(), this);
+                    ghostNodes [ 1 ] = new ElementDofManager(2, giveDomain(), this);
                 }
                 ghostNodes [ 1 ]->appendDof( new MasterDof(ghostNodes [ 1 ], mask [ val.at(i) - 7 ]) );
             }


### PR DESCRIPTION
The id given in the constructor wouldn't allow differentiating between the two ghost nodes' dofmanager when given only the pointer to it.

Beam2d.C already sets the correct ids.