### PR TITLE
Generic Improvements

### DIFF
--- a/src/oofemlib/gpexportmodule.C
+++ b/src/oofemlib/gpexportmodule.C
@@ -91,10 +91,11 @@ GPExportModule :: doOutput(TimeStep *tStep, bool forcedOutput)
     for ( int ireg = 1; ireg <= this->giveNumberOfRegions(); ireg++ ) {
         elements.followedBy(this->giveRegionSet(ireg)->giveElementList());
     }
+    elements.sort();
     
     // loop over elements
     for ( auto &elem : d->giveElements() ) {
-        if ( elements.contains(elem -> giveNumber()) ){
+        if ( elements.containsSorted(elem -> giveNumber()) ){
             
             //iRule = elem->giveDefaultIntegrationRulePtr();
             //int numIntRules = elem->giveNumberOfIntegrationRules();

--- a/src/oofemlib/homexportmodule.C
+++ b/src/oofemlib/homexportmodule.C
@@ -84,6 +84,7 @@ HOMExportModule :: doOutput(TimeStep *tStep, bool forcedOutput)
     for ( int ireg = 1; ireg <= this->giveNumberOfRegions(); ireg++ ) {
         elements.followedBy(this->giveRegionSet(ireg)->giveElementList());
     }
+    elements.sort();
     //elements.printYourself();
     
     if (!ists.isEmpty()) {
@@ -139,7 +140,7 @@ HOMExportModule :: average(FloatArray &answer, double &volTot, int ist, bool str
     Domain *d = emodel->giveDomain(1);
     for ( auto &elem : d->giveElements() ) {
         //printf("%d ", elem -> giveNumber());
-        if ( elements.contains(elem -> giveNumber()) ){
+        if ( elements.containsSorted(elem -> giveNumber()) ){
             for ( GaussPoint *gp: *elem->giveDefaultIntegrationRulePtr() ) {
                 double dV = elem->computeVolumeAround(gp);
                 volTot += dV;

--- a/src/oofemlib/staggeredproblem.C
+++ b/src/oofemlib/staggeredproblem.C
@@ -175,12 +175,11 @@ StaggeredProblem :: initializeFrom(InputRecord &ir)
     inputStreamNames.resize(2);
     if ( ir.hasField(_IFT_StaggeredProblem_prob3) ){
         inputStreamNames.resize(3);
+        IR_GIVE_FIELD(ir, inputStreamNames[ 2 ], _IFT_StaggeredProblem_prob3);
     }
     
     IR_GIVE_FIELD(ir, inputStreamNames [ 0 ], _IFT_StaggeredProblem_prob1);
     IR_GIVE_FIELD(ir, inputStreamNames [ 1 ], _IFT_StaggeredProblem_prob2);
-    IR_GIVE_OPTIONAL_FIELD(ir, inputStreamNames [ 2 ], _IFT_StaggeredProblem_prob3);
-    
     
     renumberFlag = true; // The staggered problem itself should always try to check if the sub-problems needs renumbering.
 

--- a/src/oofemlib/staggeredsolver.C
+++ b/src/oofemlib/staggeredsolver.C
@@ -329,13 +329,13 @@ StaggeredSolver :: solve(SparseMtrx &k, FloatArray &R, FloatArray *R0,
         OOFEM_LOG_INFO("StaggeredSolver:     Node            Dof             Displacement    Force\n");
         double reaction;
         for ( int i = 1; i <= numberOfPrescribedDofs; i++ ) {
-            reaction = R->at( prescribedEqs.at(i) );
+            reaction = R.at( prescribedEqs.at(i) );
             if ( R0 ) {
                 reaction += R0->at( prescribedEqs.at(i) );
             }
             lastReactions.at(i) = reaction;
             OOFEM_LOG_INFO("StaggeredSolver:     %-15d %-15d %-+15.5e %-+15.5e\n", prescribedDofs.at(2 * i - 1), prescribedDofs.at(2 * i),
-                           X.at( prescribedEqs.at(i) ), reaction);
+                           dg.X.at( prescribedEqs.at(i) ), reaction);
         }
         OOFEM_LOG_INFO("\n");
     }

--- a/src/sm/Elements/LatticeElements/lattice2dboundary.h
+++ b/src/sm/Elements/LatticeElements/lattice2dboundary.h
@@ -44,8 +44,6 @@
 #define _IFT_Lattice2dBoundary_location "location"
 //@}
 
-#define TOL 1.e-8
-
 namespace oofem {
 class Lattice2dBoundary : public Lattice2d
 {

--- a/src/sm/Elements/structuralelement.C
+++ b/src/sm/Elements/structuralelement.C
@@ -505,9 +505,8 @@ StructuralElement :: computeResultingIPTemperatureAt(FloatArray &answer, TimeSte
             if  ( bc->giveSetNumber() && bc->isImposed(tStep) ) {
                 if ( load->giveBCValType() == TemperatureBVT ) {
                     Set *set = domain->giveSet(bc->giveSetNumber() );
-                    const IntArray &elements = set->giveElementList();
 
-                    if ( elements.contains(this->giveNumber() ) ) {
+                    if ( set->hasElement(this->giveNumber() ) ) {
                         load->computeValueAt(temperature, tStep, gCoords, mode);
                         answer.add(temperature);
                     }
@@ -553,9 +552,8 @@ StructuralElement :: computeResultingIPEigenstrainAt(FloatArray &answer, TimeSte
             if  ( bc->giveSetNumber() && bc->isImposed(tStep) ) {
                 if ( load->giveBCValType() == EigenstrainBVT ) {
                     Set *set = domain->giveSet(bc->giveSetNumber() );
-                    const IntArray &elements = set->giveElementList();
 
-                    if ( elements.contains(this->giveNumber() ) ) {
+                    if ( set->hasElement(this->giveNumber() ) ) {
                         load->computeValueAt(eigenstrain, tStep, gCoords, mode);
                         answer.add(eigenstrain);
                     }

--- a/src/sm/Elements/structuralelement.C
+++ b/src/sm/Elements/structuralelement.C
@@ -38,9 +38,7 @@
 #include "sm/Materials/structuralms.h"
 #include "sm/Materials/InterfaceMaterials/structuralinterfacematerialstatus.h"
 #include "sm/Materials/LatticeMaterials/latticematstatus.h"
-#include "Loads/structtemperatureload.h"
 #include "sm/Materials/structuralnonlocalmaterialext.h"
-#include "Loads/structeigenstrainload.h"
 #include "feinterpol.h"
 #include "domain.h"
 #include "material.h"
@@ -501,15 +499,14 @@ StructuralElement :: computeResultingIPTemperatureAt(FloatArray &answer, TimeSte
     for ( int i = 1; i <= nbc; ++i ) {
         GeneralBoundaryCondition *bc = domain->giveBc(i);
 
-        if ( ( load = dynamic_cast< StructuralTemperatureLoad * >( bc ) ) ) {
-            if  ( bc->giveSetNumber() && bc->isImposed(tStep) ) {
-                if ( load->giveBCValType() == TemperatureBVT ) {
-                    Set *set = domain->giveSet(bc->giveSetNumber() );
+        if ( bc->giveBCValType() == TemperatureBVT ) {
+            if ( bc->giveSetNumber() && bc->isImposed( tStep ) ) {
+                Set *set = domain->giveSet( bc->giveSetNumber() );
 
-                    if ( set->hasElement(this->giveNumber() ) ) {
-                        load->computeValueAt(temperature, tStep, gCoords, mode);
-                        answer.add(temperature);
-                    }
+                if ( set->hasElement( this->giveNumber() ) ) {
+                    load = static_cast<Load *>( bc );
+                    load->computeValueAt( temperature, tStep, gCoords, mode );
+                    answer.add( temperature );
                 }
             }
         }
@@ -548,15 +545,14 @@ StructuralElement :: computeResultingIPEigenstrainAt(FloatArray &answer, TimeSte
     for ( int i = 1; i <= nbc; ++i ) {
         GeneralBoundaryCondition *bc = domain->giveBc(i);
 
-        if  ( ( load = dynamic_cast< StructuralEigenstrainLoad * >( bc ) ) ) {
-            if  ( bc->giveSetNumber() && bc->isImposed(tStep) ) {
-                if ( load->giveBCValType() == EigenstrainBVT ) {
-                    Set *set = domain->giveSet(bc->giveSetNumber() );
+        if ( bc->giveBCValType() == EigenstrainBVT ) {
+            if ( bc->giveSetNumber() && bc->isImposed( tStep ) ) {
+                Set *set = domain->giveSet( bc->giveSetNumber() );
 
-                    if ( set->hasElement(this->giveNumber() ) ) {
-                        load->computeValueAt(eigenstrain, tStep, gCoords, mode);
-                        answer.add(eigenstrain);
-                    }
+                if ( set->hasElement( this->giveNumber() ) ) {
+                    load = static_cast<Load *>( bc );
+                    load->computeValueAt( eigenstrain, tStep, gCoords, mode );
+                    answer.add( eigenstrain );
                 }
             }
         }

--- a/src/sm/Materials/InterfaceMaterials/intmatbilinczelastic.C
+++ b/src/sm/Materials/InterfaceMaterials/intmatbilinczelastic.C
@@ -108,10 +108,10 @@ IntMatBilinearCZElastic :: give3dStiffnessMatrix_dTdj(MatResponseMode rMode, Gau
 }
 
 
-const double tolerance = 1.0e-12; // small number
 void
 IntMatBilinearCZElastic :: initializeFrom(InputRecord &ir)
 {
+    constexpr double tolerance = 1.0e-12; // small number
     IR_GIVE_FIELD(ir, kn0, _IFT_IntMatBilinearCZElastic_kn);
     this->knc = kn0;                        // Defaults to the same stiffness in compression and tension
     IR_GIVE_OPTIONAL_FIELD(ir, this->knc, _IFT_IntMatBilinearCZElastic_knc);

--- a/src/sm/Materials/InterfaceMaterials/intmatbilinczfagerstromrate.C
+++ b/src/sm/Materials/InterfaceMaterials/intmatbilinczfagerstromrate.C
@@ -296,7 +296,6 @@ IntMatBilinearCZFagerstromRate :: giveFirstPKTraction_3d(const FloatArrayF<3> &d
 }
 
 
-const double tolerance = 1.0e-12; // small number
 void
 IntMatBilinearCZFagerstromRate :: initializeFrom(InputRecord &ir)
 {


### PR DESCRIPTION
This PR is a mix of small things.

1. The most important part is the usage of sorted containers to improve the performance of the output modules:
  whenever the boundary conditions are numerous, the retrieval of strain and stresses on an element becomes the most time consuming part, not because the computations are hard per se, but because most of the time is spent looping through all the BCs looking for which of them are applied to such element. This suggests the best practice would be to merge together equivalent boundary conditions by merging the sets. At that point, in the case of element BCs, the bottleneck would be the O(N) lookup on the elements IntArray. This fix uses the sorted IntArray inside the Set, reducing the complexity to a one shot O(NlogN) and a O(logN) for each time the lookup is performed.
  Note: since these structures are meant for lookup, in terms of performance an std::unordered_set (O(1)) would be better, but the memory footprint may be too much when the sets are a lot? 🤔 

2. The initialization of the staggered solver has `prob3` as an optional parameter. To retrieve that, the reference to the third element in the array is still passed around. This harmless in the Release build, the Debug build however performs out of bound checks and complains.

3. The rest is unused variables and macros