### PR TITLE
Resolve: cannot pass object of non-trivial type to OOFEM_WARNING

### DIFF
--- a/src/oofemlib/solutionstatusexportmodule.C
+++ b/src/oofemlib/solutionstatusexportmodule.C
@@ -148,7 +148,7 @@ SolutionStatusExportModule :: checkRecs()
     }
   }
   if (notrecognized.size()) {
-    OOFEM_WARNING ("SolutionStatusExportModule: invalid tokens detected:", notrecognized); 
+    OOFEM_WARNING ("SolutionStatusExportModule: invalid tokens detected: %s", notrecognized.c_str());
   }
 }
 


### PR DESCRIPTION
I think there is a bug in src/oofemlib/solutionstatusexportmodule.C You are passing a non-trivial object instead which will cause issues with some compilers: https://oofem.org/forum/viewtopic.php?id=1959