### PR TITLE
fix FloatMatrix.asNumpyArray + test

### DIFF
--- a/bindings/python/oofem.cpp
+++ b/bindings/python/oofem.cpp
@@ -764,7 +764,8 @@ PYBIND11_MODULE(oofempy, m) {
         .def("beProductOf", &oofem::FloatArray::beProductOf)
         // enable conversion to numpy representation
         .def("asNumpyArray", [](const oofem::FloatArray &s) {
-            return py::array_t<double> (s.giveSize(), s.givePointer());
+            // the py::cast(s) uses the parent object for determining array lifetime: https://github.com/pybind/pybind11/issues/2271#issuecomment-650565098
+            return py::array_t<double> (s.giveSize(), s.givePointer(), py::cast(s));
         })
         // expose FloatArray operators
         .def(py::self + py::self)
@@ -848,7 +849,8 @@ PYBIND11_MODULE(oofempy, m) {
         .def("plusDyadUnsym", &oofem::FloatMatrix::plusDyadUnsym)
         // enable conversion to numpy representation
         .def("asNumpyArray", [](const oofem::FloatMatrix &s) {
-            return py::array_t<double> ({s.giveNumberOfRows(), s.giveNumberOfColumns()}, {sizeof(double), sizeof(double)*s.giveNumberOfRows()}, s.givePointer());
+            // the py::cast(s) uses the parent object for determining array lifetime: https://github.com/pybind/pybind11/issues/2271#issuecomment-650565098
+            return py::array_t<double> ({s.giveNumberOfRows(), s.giveNumberOfColumns()}, {sizeof(double), sizeof(double)*s.giveNumberOfRows()}, s.givePointer(), py::cast(s));
         })
         // expose FloatArray operators
         .def(py::self + py::self)

--- a/bindings/python/tests/test_1.py
+++ b/bindings/python/tests/test_1.py
@@ -56,5 +56,12 @@ def test_1():
     assert (round(y[2]-3.0, 6) == 0)
     print(y)
 
+    # test that asNumpyArray return view to the original data
+    a0=oofempy.FloatMatrix(3,3)
+    a1=a0.asNumpyArray()
+    a1[0,2]=99
+    assert a1[0,2]==a0[0,2]
+    assert a0[0,2]==99
+
 if __name__ == "__main__":
     test_1()


### PR DESCRIPTION
@bpatzak  This is just a fix.

In general I believe [nanobind](https://github.com/wjakob/nanobind) has a superior infrastructure ([nanobind::ndarray](https://nanobind.readthedocs.io/en/latest/ndarray.html)) for automatic conversion of user-defined types (such as `FloatMatrix` and `FloatArray`) into numpy arrays (both ways) so that the c++ types don't appear in the python land at all (see e.g. [Eigen dense matrix type_caster](https://github.com/wjakob/nanobind/blob/master/include/nanobind/eigen/dense.h) is done: I find it impressively concise, the same could be done for `FloatMatrix` and `FloatArray`).