### PR TITLE
Optionally use nanobind instead of pybind11 (-DUSE_NANOBIND)

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -34,6 +34,10 @@ notshared:
 	cmake -Bbuild -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
 	ninja -C build/
 	ctest --test-dir build/ --parallel=16
+nanobind:
+	cmake -Bbuild-nanobind -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_NANOBIND=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
+	ninja -C build-nanobind
+	ctest --test-dir build/ --output-on-failure --parallel=16
 act-install:
 	#!/bin/bash
 	[ -f .cache/nektos-act ] || mkdir -p .cache && wget https://github.com/nektos/act/releases/download/v0.2.76/act_Linux_x86_64.tar.gz && tar xvfz act_Linux_x86_64.tar.gz act && rm act_Linux_x86_64.tar.gz && mv ./act .cache/nektos-act && chmod a+x .cache/nektos-act

--- a/.justfile
+++ b/.justfile
@@ -57,3 +57,6 @@ msvc:
 pytest:
 	#!/bin/bash
 	PYTHONPATH=build:bindings/python python -m pytest bindings/python/tests
+test-ext:
+	# ctest --test-dir build/ -VV --output-on-failure -R test_sm_python_usrdefboundaryload01.in
+	gdb -ex=run -args build/oofem -f tests/sm/python/usrdefboundaryload01.in

--- a/.justfile
+++ b/.justfile
@@ -25,19 +25,19 @@ pyodide:
 	pip install pytest numpy
 	cd bindings/python/tests; python -m pytest
 shared:
-	mkdir -p build
-	cmake -Bbuild -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=1 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
-	ninja -C build/
-	ctest --test-dir build/ --parallel=16 --output-on-failure
+	mkdir -p build-shared
+	cmake -Bbuild-shared -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=1 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
+	ninja -C build-shared/
+	ctest --test-dir build-shared/ --parallel=16 --output-on-failure
 notshared:
-	mkdir -p build
-	cmake -Bbuild -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
-	ninja -C build/
-	ctest --test-dir build/ --parallel=16
+	mkdir -p build-notshared
+	cmake -Bbuild-notshared -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
+	ninja -C build-notshared/
+	ctest --test-dir build-notshared/ --parallel=16
 nanobind:
 	cmake -Bbuild-nanobind -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_NANOBIND=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
 	ninja -C build-nanobind
-	ctest --test-dir build/ --output-on-failure --parallel=16
+	ctest --test-dir build-nanobind/ --output-on-failure --parallel=16
 act-install:
 	#!/bin/bash
 	[ -f .cache/nektos-act ] || mkdir -p .cache && wget https://github.com/nektos/act/releases/download/v0.2.76/act_Linux_x86_64.tar.gz && tar xvfz act_Linux_x86_64.tar.gz act && rm act_Linux_x86_64.tar.gz && mv ./act .cache/nektos-act && chmod a+x .cache/nektos-act

--- a/.justfile
+++ b/.justfile
@@ -31,7 +31,7 @@ shared:
 	ctest --test-dir build/ --parallel=16 --output-on-failure
 notshared:
 	mkdir -p build
-	cmake -Bbuild -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
+	cmake -Bbuild -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
 	ninja -C build/
 	ctest --test-dir build/ --parallel=16
 nanobind:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,7 @@ if(USE_NANOBIND AND NOT USE_PYBIND_BINDINGS)
 endif()
 
 if (USE_PYBIND_BINDINGS)
+    add_definitions(-D_PYBIND_BINDINGS)
     # workaround for emscripten: https://github.com/pyodide/pyodide/issues/5054
     set(PYBIND11_FINDPYTHON ON)
     find_package(Python COMPONENTS Interpreter Development)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,7 @@ if(USE_NANOBIND AND NOT USE_PYBIND_BINDINGS)
 endif()
 
 if (USE_PYBIND_BINDINGS)
+    add_definitions(-D_PYBIND_BINDINGS)
     if(USE_NANOBIND)
         add_subdirectory(extern/nanobind)
         find_package(Python COMPONENTS Interpreter Development)
@@ -704,8 +705,12 @@ if (USE_PYBIND_BINDINGS)
         endif()
         set(PYBIND11_PYTEST_FOUND TRUE CACHE INTERNAL "")
     endif()
-    add_definitions(-D_PYBIND_BINDINGS)
 endif()
+
+
+if(USE_PYTHON_EXTENSION)
+    add_definitions(-D_PYTHON_EXTENSION)
+endif ()
 
 #######################################################################
 ######################## Configuration ################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,20 +656,24 @@ if(USE_NANOBIND AND NOT USE_PYBIND_BINDINGS)
 endif()
 
 if (USE_PYBIND_BINDINGS)
-    add_definitions(-D_PYBIND_BINDINGS)
+    # workaround for emscripten: https://github.com/pyodide/pyodide/issues/5054
+    set(PYBIND11_FINDPYTHON ON)
+    find_package(Python COMPONENTS Interpreter Development)
     if(USE_NANOBIND)
         add_subdirectory(extern/nanobind)
-        find_package(Python COMPONENTS Interpreter Development)
+        #include(FetchContent)
+        #FetchContent_Declare(
+        #    nanobind
+        #    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+        #    GIT_TAG v2.7.0
+        #)
+        #FetchContent_MakeAvailable(nanobind)
         nanobind_add_module(oofempy NB_STATIC STABLE_ABI LTO ${oofem_SOURCE_DIR}/bindings/python/oofem.cpp)
         nanobind_build_library(nanobind-static)
         link_libraries(nanobind-static)
         add_definitions(-D_USE_NANOBIND)
         include_directories(${oofem_SOURCE_DIR}/extern/nanobind/include)
     else()
-        # workaround for emscripten: https://github.com/pyodide/pyodide/issues/5054
-        set(PYBIND11_FINDPYTHON ON)
-
-        find_package(Python COMPONENTS Interpreter Development)
         if (PYBIND_DIR)
             message(STATUS "PYBIND_DIR = ${PYBIND_DIR}")
             include_directories (${PYBIND_DIR}) # need also to manually set it up since it can be anywhere
@@ -707,10 +711,11 @@ if (USE_PYBIND_BINDINGS)
     endif()
 endif()
 
-
 if(USE_PYTHON_EXTENSION)
+    find_package(Python COMPONENTS Interpreter Development)
     add_definitions(-D_PYTHON_EXTENSION)
-endif ()
+    link_libraries(Python::Python)
+endif()
 
 #######################################################################
 ######################## Configuration ################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ option (USE_CEMHYD "Enable CemHyd support" OFF)
 option (USE_AM "Enable additive manufacturing module" OFF)
 option (USE_T3D "Enable T3D support" OFF)
 option (USE_PYBIND_BINDINGS "Enable Python Pybind11 bindings (OOFEM callable from Python and vice versa)." OFF)
+option (USE_NANOBIND "Use nanobind instead of pybind; requires USE_PYBIND_BINDINGS" OFF)
 option (USE_PYTHON_EXTENSION "Enable Python extension for exposing C++ code to python. Uses Python.h library." OFF)
 option (USE_HDF5 "HDF5 support" OFF)
 option (USE_MPM "Enable experimental multiphysics module" OFF)
@@ -644,31 +645,41 @@ endif()
 
 
 
-
-
-if (USE_PYBIND_BINDINGS OR USE_PYTHON_EXTENSION)
-    # workaround for emscripten: https://github.com/pyodide/pyodide/issues/5054
-    set(PYBIND11_FINDPYTHON ON)
-
-    find_package(Python COMPONENTS Interpreter Development)
-    if (PYBIND_DIR)
-        message(STATUS "PYBIND_DIR = ${PYBIND_DIR}")
-        include_directories (${PYBIND_DIR}) # need also to manually set it up since it can be anywhere
-        add_git_submodule(${PYBIND_DIR})
-    else()
-        add_git_submodule(extern/pybind11)
-    endif ()
-
-    # use python include paths and libs for all future targets (liboofem and oofem binary)
-    link_libraries(pybind11::embed)
-endif()
-
 if(USE_PYTHON_EXTENSION)
     add_definitions(-D_PYTHON_EXTENSION)
+    find_package(Python COMPONENTS Interpreter Development)
+    link_libraries(Python::Python)
 endif ()
 
-if(USE_PYBIND_BINDINGS)
-    pybind11_add_module(oofempy THIN_LTO ${oofem_SOURCE_DIR}/bindings/python/oofem.cpp)
+if(USE_NANOBIND AND NOT USE_PYBIND_BINDINGS)
+    MESSAGE(FATAL_ERROR "USE_NANOBIND requires simultaneous USE_PYBIND_BINDINGS")
+endif()
+
+if (USE_PYBIND_BINDINGS)
+    if(USE_NANOBIND)
+        add_subdirectory(extern/nanobind)
+        find_package(Python COMPONENTS Interpreter Development)
+        nanobind_add_module(oofempy NB_STATIC STABLE_ABI LTO ${oofem_SOURCE_DIR}/bindings/python/oofem.cpp)
+        nanobind_build_library(nanobind-static)
+        link_libraries(nanobind-static)
+        add_definitions(-D_USE_NANOBIND)
+        include_directories(${oofem_SOURCE_DIR}/extern/nanobind/include)
+    else()
+        # workaround for emscripten: https://github.com/pyodide/pyodide/issues/5054
+        set(PYBIND11_FINDPYTHON ON)
+
+        find_package(Python COMPONENTS Interpreter Development)
+        if (PYBIND_DIR)
+            message(STATUS "PYBIND_DIR = ${PYBIND_DIR}")
+            include_directories (${PYBIND_DIR}) # need also to manually set it up since it can be anywhere
+            add_git_submodule(${PYBIND_DIR})
+        else()
+            add_git_submodule(extern/pybind11)
+        endif ()
+        # use python include paths and libs for all future targets (liboofem and oofem binary)
+        link_libraries(pybind11::embed)
+        pybind11_add_module(oofempy THIN_LTO ${oofem_SOURCE_DIR}/bindings/python/oofem.cpp)
+    endif()
     if(USE_SHARED_LIB)
         if(EMSCRIPTEN)
             MESSAGE(FATAL_ERROR "USE_SHARED_LIB=1 is incompatible with Emscripten (some unresolved symbols at runtime).")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ if(PY_BUILD_CMAKE_IMPORT_NAME)
     set(SKBUILD_PROJECT_VERSION_FULL ${PY_BUILD_CMAKE_PROJECT_VERSION}) # PY_BUILD_CMAKE does not provide VERSION_FULL (?)
 endif()
 
+include (FetchContent)
 include (CheckSymbolExists)
 include (CheckCXXSymbolExists)
 include (CheckIncludeFiles)
@@ -660,18 +661,21 @@ if (USE_PYBIND_BINDINGS)
     # workaround for emscripten: https://github.com/pyodide/pyodide/issues/5054
     set(PYBIND11_FINDPYTHON ON)
     find_package(Python COMPONENTS Interpreter Development)
+    link_libraries(Python::Python)
     if(USE_NANOBIND)
-        add_subdirectory(extern/nanobind)
-        #include(FetchContent)
-        #FetchContent_Declare(
-        #    nanobind
-        #    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-        #    GIT_TAG v2.7.0
-        #)
-        #FetchContent_MakeAvailable(nanobind)
+        if(0)
+            add_subdirectory(extern/nanobind)
+        else()
+            FetchContent_Declare(
+                nanobind
+                GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+                GIT_TAG v2.7.0
+            )
+            FetchContent_MakeAvailable(nanobind)
+        endif()
         nanobind_add_module(oofempy NB_STATIC STABLE_ABI LTO ${oofem_SOURCE_DIR}/bindings/python/oofem.cpp)
-        nanobind_build_library(nanobind-static)
-        link_libraries(nanobind-static)
+        nanobind_build_library(nanobind-static) # -static is added via NB_STATIC for the module
+        link_libraries(nanobind-static) # for pythonfield.C and possibly others using nanobind functions
         add_definitions(-D_USE_NANOBIND)
         include_directories(${oofem_SOURCE_DIR}/extern/nanobind/include)
     else()

--- a/bindings/python/oofem.cpp
+++ b/bindings/python/oofem.cpp
@@ -770,7 +770,8 @@ PYBIND11_MODULE(oofempy, m) {
         .def("beProductOf", &oofem::FloatArray::beProductOf)
         // enable conversion to numpy representation
         .def("asNumpyArray", [](const oofem::FloatArray &s) {
-            return py::array_t<double> (s.giveSize(), s.givePointer());
+            // the py::cast(s) uses the parent object for determining array lifetime: https://github.com/pybind/pybind11/issues/2271#issuecomment-650565098
+            return py::array_t<double> (s.giveSize(), s.givePointer(), py::cast(s));
         })
         // expose FloatArray operators
         .def(py::self + py::self)
@@ -854,7 +855,8 @@ PYBIND11_MODULE(oofempy, m) {
         .def("plusDyadUnsym", &oofem::FloatMatrix::plusDyadUnsym)
         // enable conversion to numpy representation
         .def("asNumpyArray", [](const oofem::FloatMatrix &s) {
-            return py::array_t<double> ({s.giveNumberOfRows(), s.giveNumberOfColumns()}, {sizeof(double), sizeof(double)*s.giveNumberOfRows()}, s.givePointer());
+            // the py::cast(s) uses the parent object for determining array lifetime: https://github.com/pybind/pybind11/issues/2271#issuecomment-650565098
+            return py::array_t<double> ({s.giveNumberOfRows(), s.giveNumberOfColumns()}, {sizeof(double), sizeof(double)*s.giveNumberOfRows()}, s.givePointer(), py::cast(s));
         })
         // expose FloatArray operators
         .def(py::self + py::self)

--- a/bindings/python/oofemarray-nanobind.h
+++ b/bindings/python/oofemarray-nanobind.h
@@ -5,9 +5,6 @@
 #include "floatarrayf.h"
 #include "floatmatrixf.h"
 #include "intarray.h"
-using oofem::FloatMatrix;
-using oofem::FloatArray;
-using oofem::IntArray;
 
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
@@ -18,48 +15,42 @@ template<typename T, typename T2=void> struct _ArrayInfo{};
 
 
 struct _ArrayInfo1d{
-    static constexpr int Dim=1;
     typedef nb::shape<-1> Shape;
     typedef nb::f_contig Contig;
     template<typename T>
     static void resize(T& v, size_t shape0, size_t shape1){ v.resize(shape0); }
-    template<typename T, typename Scalar>
+    template<typename T>
     static void shape_strides_size(const T& v, size_t shape[2], int64_t strides[2], size_t& size){
         shape[0]=v.size(); shape[1]=0; strides[0]=1; strides[1]=0; size=v.size();
     };
 
 };
 struct _ArrayInfo2d{
-    static constexpr int Dim=2;
     typedef nb::shape<-1,-1> Shape;
     typedef nb::f_contig Contig;
     template<typename T>
     static void resize(T& v, size_t shape0, size_t shape1){ v.resize(shape0,shape1); }
-    template<typename T, typename Scalar>
+    template<typename T>
     static void shape_strides_size(const T& v, size_t shape[2], int64_t strides[2], size_t& size){
         shape[0]=v.giveNumberOfRows(); shape[1]=v.giveNumberOfColumns(); strides[0]=1; strides[1]=v.giveNumberOfRows(); size=v.giveNumberOfRows()*v.giveNumberOfColumns();
     };
 };
-template<> struct _ArrayInfo<FloatMatrix>: public _ArrayInfo2d{
-    typedef double Scalar;
-    typedef FloatMatrix T;
-};
-
-template<> struct _ArrayInfo<FloatArray>: public _ArrayInfo1d{
-    typedef double Scalar;
-    typedef FloatArray T;
-};
-template<> struct _ArrayInfo<IntArray>: public _ArrayInfo1d{
-    typedef int Scalar;
-    typedef IntArray T;
-};
+template<> struct _ArrayInfo<::oofem::FloatMatrix>: public _ArrayInfo2d{};
+template<> struct _ArrayInfo<::oofem::FloatArray>: public _ArrayInfo1d{};
+template<> struct _ArrayInfo<::oofem::IntArray>: public _ArrayInfo1d{};
 
 template<typename T>
-struct type_caster<T,std::enable_if_t<std::is_same<T,FloatMatrix>::value || std::is_same<T,FloatArray>::value || std::is_same<T,IntArray>::value,int>>
-  {
+struct type_caster<
+    T,std::enable_if_t<
+        std::is_same<T,::oofem::FloatMatrix>::value || std::is_same<T,::oofem::FloatArray>::value || std::is_same<T,::oofem::IntArray>::value
+       ,int
+    >
+>
+{
+    using Scalar = typename T::Scalar;
     using Info = _ArrayInfo<T>;
-    using NDArray = nanobind::ndarray<typename Info::Scalar,nanobind::numpy,typename Info::Shape,typename Info::Contig>;
-    using NDArrayConst = nanobind::ndarray<const typename Info::Scalar,nanobind::numpy,typename Info::Shape,typename Info::Contig>;
+    using NDArray = nanobind::ndarray<Scalar,nanobind::numpy,typename Info::Shape,typename Info::Contig>;
+    using NDArrayConst = nanobind::ndarray<Scalar,nanobind::numpy,typename Info::Shape,typename Info::Contig>;
     using NDArrayCaster = make_caster<NDArray>;
     using NDArrayCasterConst = make_caster<NDArrayConst>;
 
@@ -78,12 +69,9 @@ struct type_caster<T,std::enable_if_t<std::is_same<T,FloatMatrix>::value || std:
         const NDArrayConst &array = caster.value;
         Info::resize(value,array.shape(0),array.shape(1));
         // The layout is contiguous & compatible thanks to array_for_eigen_t<T>
-        memcpy(value.givePointer(), array.data(), array.size() * sizeof(typename Info::Scalar));
+        memcpy(value.givePointer(), array.data(), array.size() * sizeof(Scalar));
         return true;
     }
-
-    template<typename T2>
-    static void hithere(T2&& v){};
 
     template <typename T2>
     static handle from_cpp(T2 &&v, rv_policy policy, cleanup_list *cleanup) noexcept {
@@ -99,13 +87,13 @@ struct type_caster<T,std::enable_if_t<std::is_same<T,FloatMatrix>::value || std:
         size_t shape[2];
         int64_t strides[2];
         size_t size;
-        Info::template shape_strides_size<T,typename Info::Scalar>(v,shape,strides,size);
+        Info::template shape_strides_size<T>(v,shape,strides,size);
         // std::cerr<<"    from_cpp_internal[shape=["<<shape[0]<<","<<shape[1]<<"],strides=["<<strides[0]<<","<<strides[1]<<"],size="<<size<<"]"<<std::endl;
         void *ptr = (void *) v.givePointer();
-		  // for(int i=0; i<size; i++) std::cerr<<"["<<i<<"] → "<<*(double*)(((void*)v.givePointer())+i*sizeof(double))<<std::endl;
+        // for(int i=0; i<size; i++) std::cerr<<"["<<i<<"] → "<<*(double*)(((void*)v.givePointer())+i*sizeof(double))<<std::endl;
         if (policy == rv_policy::move) {
             // Don't bother moving when the data is static or occupies <1KB
-            if (size < (1024 / sizeof(typename Info::Scalar))) policy = rv_policy::copy;
+            if (size < (1024 / sizeof(Scalar))) policy = rv_policy::copy;
         }
 
         object owner;
@@ -120,7 +108,7 @@ struct type_caster<T,std::enable_if_t<std::is_same<T,FloatMatrix>::value || std:
         }
 
         object o = steal(NDArrayCaster::from_cpp(
-            NDArray(ptr, Info::Dim, shape, owner, strides), policy, cleanup)
+            NDArray(ptr, T::Dim, shape, owner, strides), policy, cleanup)
         );
 
         return o.release();

--- a/bindings/python/oofemarray-nanobind.h
+++ b/bindings/python/oofemarray-nanobind.h
@@ -1,3 +1,14 @@
+#pragma once
+#include <nanobind/ndarray.h>
+#include <iostream>
+#include "floatmatrix.h"
+#include "floatarrayf.h"
+#include "floatmatrixf.h"
+#include "intarray.h"
+using oofem::FloatMatrix;
+using oofem::FloatArray;
+using oofem::IntArray;
+
 NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
@@ -9,12 +20,12 @@ template<typename T, typename T2=void> struct _ArrayInfo{};
 struct _ArrayInfo1d{
     static constexpr int Dim=1;
     typedef nb::shape<-1> Shape;
-    typedef nb::c_contig Contig;
+    typedef nb::f_contig Contig;
     template<typename T>
     static void resize(T& v, size_t shape0, size_t shape1){ v.resize(shape0); }
     template<typename T, typename Scalar>
     static void shape_strides_size(const T& v, size_t shape[2], int64_t strides[2], size_t& size){
-        shape[0]=v.size(); shape[1]=0; strides[0]=sizeof(Scalar); strides[1]=0; size=v.size();
+        shape[0]=v.size(); shape[1]=0; strides[0]=1; strides[1]=0; size=v.size();
     };
 
 };
@@ -26,7 +37,7 @@ struct _ArrayInfo2d{
     static void resize(T& v, size_t shape0, size_t shape1){ v.resize(shape0,shape1); }
     template<typename T, typename Scalar>
     static void shape_strides_size(const T& v, size_t shape[2], int64_t strides[2], size_t& size){
-        shape[0]=v.giveRowSize(); shape[1]=v.giveColSize(); strides[0]=sizeof(Scalar); strides[1]=sizeof(Scalar)*v.giveRowSize(); size=v.giveRowSize()*v.giveColSize();
+        shape[0]=v.giveNumberOfRows(); shape[1]=v.giveNumberOfColumns(); strides[0]=1; strides[1]=v.giveNumberOfRows(); size=v.giveNumberOfRows()*v.giveNumberOfColumns();
     };
 };
 template<> struct _ArrayInfo<FloatMatrix>: public _ArrayInfo2d{
@@ -43,12 +54,12 @@ template<> struct _ArrayInfo<IntArray>: public _ArrayInfo1d{
     typedef IntArray T;
 };
 
-template<>
-struct type_caster<FloatMatrix> {
-    using T = FloatMatrix;
+template<typename T>
+struct type_caster<T,std::enable_if_t<std::is_same<T,FloatMatrix>::value || std::is_same<T,FloatArray>::value || std::is_same<T,IntArray>::value,int>>
+  {
     using Info = _ArrayInfo<T>;
-    using NDArray = nanobind::ndarray<Info::Scalar,nanobind::numpy,Info::Shape,Info::Contig>;
-    using NDArrayConst = nanobind::ndarray<const Info::Scalar,nanobind::numpy,Info::Shape,Info::Contig>;
+    using NDArray = nanobind::ndarray<typename Info::Scalar,nanobind::numpy,typename Info::Shape,typename Info::Contig>;
+    using NDArrayConst = nanobind::ndarray<const typename Info::Scalar,nanobind::numpy,typename Info::Shape,typename Info::Contig>;
     using NDArrayCaster = make_caster<NDArray>;
     using NDArrayCasterConst = make_caster<NDArrayConst>;
 
@@ -56,20 +67,27 @@ struct type_caster<FloatMatrix> {
 
     bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
         // We're in any case making a copy, so non-writable inputs area also okay
-        //using NDArrayConst = array_for_eigen_t<T, const typename T::Scalar>;
-        //make_caster<NDArrayConst> caster;
+        // std::cerr<<"@@ from_python["<<<<std::endl;
+        // std::cerr<<"@@    ["<<nb::str(nb::steal(src).attr("__class__")).c_str()<<"]"<<std::endl;
         NDArrayCasterConst caster;
-        if (!caster.from_python(src, flags & ~(uint8_t)cast_flags::accepts_none, cleanup))
+        if (!caster.from_python(src, flags & ~(uint8_t)cast_flags::accepts_none, cleanup)){
+            // std::cerr<<"@@   → ERROR"<<std::endl;
+            // std::cerr<<"from_python["<<typeid(T).name()<<"]: failure; the object passed must be a numpy.array."<<std::endl;
             return false;
+        }
         const NDArrayConst &array = caster.value;
         Info::resize(value,array.shape(0),array.shape(1));
         // The layout is contiguous & compatible thanks to array_for_eigen_t<T>
-        memcpy(value.givePointer(), array.data(), array.size() * sizeof(Info::Scalar));
+        memcpy(value.givePointer(), array.data(), array.size() * sizeof(typename Info::Scalar));
         return true;
     }
 
+    template<typename T2>
+    static void hithere(T2&& v){};
+
     template <typename T2>
     static handle from_cpp(T2 &&v, rv_policy policy, cleanup_list *cleanup) noexcept {
+        // std::cerr<<"@@ from_cpp["<<typeid(v).name()<<"]"<<std::endl;
         policy = infer_policy<T2>(policy);
         if constexpr (std::is_pointer_v<T2>)
             return from_cpp_internal((const T &) *v, policy, cleanup);
@@ -81,11 +99,13 @@ struct type_caster<FloatMatrix> {
         size_t shape[2];
         int64_t strides[2];
         size_t size;
-        Info::shape_strides_size<T,Info::Scalar>(v,shape,strides,size);
+        Info::template shape_strides_size<T,typename Info::Scalar>(v,shape,strides,size);
+        // std::cerr<<"    from_cpp_internal[shape=["<<shape[0]<<","<<shape[1]<<"],strides=["<<strides[0]<<","<<strides[1]<<"],size="<<size<<"]"<<std::endl;
         void *ptr = (void *) v.givePointer();
+		  // for(int i=0; i<size; i++) std::cerr<<"["<<i<<"] → "<<*(double*)(((void*)v.givePointer())+i*sizeof(double))<<std::endl;
         if (policy == rv_policy::move) {
             // Don't bother moving when the data is static or occupies <1KB
-            if (size < (1024 / sizeof(Info::Scalar))) policy = rv_policy::copy;
+            if (size < (1024 / sizeof(typename Info::Scalar))) policy = rv_policy::copy;
         }
 
         object owner;

--- a/bindings/python/oofemarray.h
+++ b/bindings/python/oofemarray.h
@@ -1,0 +1,112 @@
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+namespace nb=::nanobind;
+
+template<typename T, typename T2=void> struct _ArrayInfo{};
+
+
+struct _ArrayInfo1d{
+    static constexpr int Dim=1;
+    typedef nb::shape<-1> Shape;
+    typedef nb::c_contig Contig;
+    template<typename T>
+    static void resize(T& v, size_t shape0, size_t shape1){ v.resize(shape0); }
+    template<typename T, typename Scalar>
+    static void shape_strides_size(const T& v, size_t shape[2], int64_t strides[2], size_t& size){
+        shape[0]=v.size(); shape[1]=0; strides[0]=sizeof(Scalar); strides[1]=0; size=v.size();
+    };
+
+};
+struct _ArrayInfo2d{
+    static constexpr int Dim=2;
+    typedef nb::shape<-1,-1> Shape;
+    typedef nb::f_contig Contig;
+    template<typename T>
+    static void resize(T& v, size_t shape0, size_t shape1){ v.resize(shape0,shape1); }
+    template<typename T, typename Scalar>
+    static void shape_strides_size(const T& v, size_t shape[2], int64_t strides[2], size_t& size){
+        shape[0]=v.giveRowSize(); shape[1]=v.giveColSize(); strides[0]=sizeof(Scalar); strides[1]=sizeof(Scalar)*v.giveRowSize(); size=v.giveRowSize()*v.giveColSize();
+    };
+};
+template<> struct _ArrayInfo<FloatMatrix>: public _ArrayInfo2d{
+    typedef double Scalar;
+    typedef FloatMatrix T;
+};
+
+template<> struct _ArrayInfo<FloatArray>: public _ArrayInfo1d{
+    typedef double Scalar;
+    typedef FloatArray T;
+};
+template<> struct _ArrayInfo<IntArray>: public _ArrayInfo1d{
+    typedef int Scalar;
+    typedef IntArray T;
+};
+
+template<>
+struct type_caster<FloatMatrix> {
+    using T = FloatMatrix;
+    using Info = _ArrayInfo<T>;
+    using NDArray = nanobind::ndarray<Info::Scalar,nanobind::numpy,Info::Shape,Info::Contig>;
+    using NDArrayConst = nanobind::ndarray<const Info::Scalar,nanobind::numpy,Info::Shape,Info::Contig>;
+    using NDArrayCaster = make_caster<NDArray>;
+    using NDArrayCasterConst = make_caster<NDArrayConst>;
+
+    NB_TYPE_CASTER(T, NDArrayCaster::Name)
+
+    bool from_python(handle src, uint8_t flags, cleanup_list *cleanup) noexcept {
+        // We're in any case making a copy, so non-writable inputs area also okay
+        //using NDArrayConst = array_for_eigen_t<T, const typename T::Scalar>;
+        //make_caster<NDArrayConst> caster;
+        NDArrayCasterConst caster;
+        if (!caster.from_python(src, flags & ~(uint8_t)cast_flags::accepts_none, cleanup))
+            return false;
+        const NDArrayConst &array = caster.value;
+        Info::resize(value,array.shape(0),array.shape(1));
+        // The layout is contiguous & compatible thanks to array_for_eigen_t<T>
+        memcpy(value.givePointer(), array.data(), array.size() * sizeof(Info::Scalar));
+        return true;
+    }
+
+    template <typename T2>
+    static handle from_cpp(T2 &&v, rv_policy policy, cleanup_list *cleanup) noexcept {
+        policy = infer_policy<T2>(policy);
+        if constexpr (std::is_pointer_v<T2>)
+            return from_cpp_internal((const T &) *v, policy, cleanup);
+        else
+            return from_cpp_internal((const T &) v, policy, cleanup);
+    }
+
+    static handle from_cpp_internal(const T &v, rv_policy policy, cleanup_list *cleanup) noexcept {
+        size_t shape[2];
+        int64_t strides[2];
+        size_t size;
+        Info::shape_strides_size<T,Info::Scalar>(v,shape,strides,size);
+        void *ptr = (void *) v.givePointer();
+        if (policy == rv_policy::move) {
+            // Don't bother moving when the data is static or occupies <1KB
+            if (size < (1024 / sizeof(Info::Scalar))) policy = rv_policy::copy;
+        }
+
+        object owner;
+        if (policy == rv_policy::move) {
+            T *temp = new T(std::move(v));
+            owner = capsule(temp, [](void *p) noexcept { delete (T *) p; });
+            ptr = temp->givePointer();
+            policy = rv_policy::reference;
+        } else if (policy == rv_policy::reference_internal && cleanup->self()) {
+            owner = borrow(cleanup->self());
+            policy = rv_policy::reference;
+        }
+
+        object o = steal(NDArrayCaster::from_cpp(
+            NDArray(ptr, Info::Dim, shape, owner, strides), policy, cleanup)
+        );
+
+        return o.release();
+    }
+};
+
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)

--- a/bindings/python/oofemutil.h
+++ b/bindings/python/oofemutil.h
@@ -1,6 +1,17 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/operators.h>
-namespace py = pybind11;
+#ifdef _USE_NANOBIND
+    #include <nanobind/nanobind.h>
+    #include <nanobind/operators.h>
+    #include <nanobind/stl/string.h>
+    namespace py = nanobind;
+    #define PY_STD_STRING(s) std::string(s.c_str())
+    #define PY_CAST(a,b) py::cast<a>(b)
+#else
+    #include <pybind11/pybind11.h>
+    #include <pybind11/operators.h>
+    namespace py = pybind11;
+    #define PY_STD_STRING(s) std::string(s)
+    #define PY_CAST(a,b) b.cast<a>()
+#endif
 #include <string>
 #include <iostream>
 // for alternative tokens like 'or' 
@@ -38,7 +49,7 @@ oofem::OOFEMTXTInputRecord makeOOFEMTXTInputRecordFrom(py::kwargs &kw)
     std::string space= " ";
     
     for (auto item: kw) {
-        std::string key = std::string(py::str(item.first));
+        std::string key = PY_STD_STRING(py::str(item.first));
         py::handle value = item.second;
         if ((strcasecmp(std::string(key).c_str(), "number") == 0) or (strcasecmp(std::string(key).c_str(), "domain") == 0))
             continue;
@@ -81,8 +92,12 @@ oofem::OOFEMTXTInputRecord makeOOFEMTXTInputRecordFrom(py::kwargs &kw)
                 } else {
                     // todo: error handling when conversion fails
                     py::handle h = item; // handle case when reference to object given; check reference counting
-                    auto o = h.cast<py::object>();
-                    oofem::FEMComponent* f = o.cast<oofem::FEMComponent*> ();
+                    #if _USE_NANOBIND
+                        oofem::FEMComponent* f = py::cast<oofem::FEMComponent*>(h);
+                    #else
+                        auto o = h.cast<py::object>();
+                        oofem::FEMComponent* f = o.cast<oofem::FEMComponent*> ();
+                    #endif
                     rec.append(space);
                     rec.append(std::to_string(f->giveNumber()));
 
@@ -97,8 +112,12 @@ oofem::OOFEMTXTInputRecord makeOOFEMTXTInputRecordFrom(py::kwargs &kw)
         } else { // handle case when reference to object given; check reference counting
             // todo: error handling when conversion fails
             py::handle h = value;
-            auto o = h.cast<py::object>();
-            oofem::FEMComponent* f = o.cast<oofem::FEMComponent*> ();
+            #if _USE_NANOBIND
+                oofem::FEMComponent* f = py::cast<oofem::FEMComponent*>(h);
+            #else
+                auto o = h.cast<py::object>();
+                oofem::FEMComponent* f = o.cast<oofem::FEMComponent*> ();
+            #endif
             rec.append(space);
             rec.append(std::to_string(f->giveNumber()));
         }
@@ -121,7 +140,7 @@ oofem::OOFEMTXTInputRecord makeOutputManagerOOFEMTXTInputRecordFrom(py::kwargs k
     py::kwargs kw2;
 
     for (auto item: kw) {
-        std::string key = std::string(py::str(item.first));
+        std::string key = PY_STD_STRING(py::str(item.first));
         py::handle value = item.second;
 
         transform(key.begin(), key.end(), key.begin(), ::tolower);
@@ -147,7 +166,7 @@ py::object createEngngModelOfType(const char* type, py::args args, py::kwargs kw
 {
     //args
     int number = len(args)>0? PyLong_AsUnsignedLong(args[0].ptr()) : 0;
-    oofem::EngngModel* master = len(args)>1? args[1].cast<oofem::EngngModel *>() : nullptr;
+    oofem::EngngModel* master = len(args)>1? PY_CAST(oofem::EngngModel *,args[1]) : nullptr;
     std::unique_ptr<EngngModel> engngm = classFactory.createEngngModel(type,number,master);
     if ( !engngm ) { OOFEM_RAISE("engngModel: wrong input data"); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -198,8 +217,8 @@ py::object domain(py::args args, py::kwargs kw)
     // args
     int number =             len(args)>0? PyLong_AsUnsignedLong(args[0].ptr()) : 0;
     int serialNumber =       len(args)>1? PyLong_AsUnsignedLong(args[1].ptr()) : 0;
-    EngngModel *engngModel = len(args)>2? args[2].cast<oofem::EngngModel *>() : nullptr;
-    domainType dType =       len(args)>3? args[3].cast<domainType>(): oofem::domainType::_unknownMode;
+    EngngModel *engngModel = len(args)>2? PY_CAST(oofem::EngngModel *,args[2]) : nullptr;
+    domainType dType =       len(args)>3? PY_CAST(domainType,args[3]): oofem::domainType::_unknownMode;
     auto d = std::make_unique<Domain>(number,serialNumber,engngModel);
     d->setDomainType(dType);
     // output manager record
@@ -223,7 +242,7 @@ py::object createElementOfType(const char* type, py::args args, py::kwargs kw)
     
     // extracts values from args if they are specified
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     /* ????????????????
     // if no material is specified, set it to 1
     if (!kw.has_key("mat")) { kw["mat"] = 1; }
@@ -316,7 +335,7 @@ py::object l1(py::args args, py::kwargs &kw) { return createElementOfType("l1",a
 py::object createDofManagerOfType(const char*type, py::args args, py::kwargs &kw)
 {
     unsigned long number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     auto dofMan = oofem::classFactory.createDofManager(type,number,domain);
     if (!dofMan) { OOFEM_RAISE("dofManager: wrong input data"); }
     dofMan->setGlobalNumber(number);
@@ -337,7 +356,7 @@ py::object hangingnode(py::args args, py::kwargs kw) { return createDofManagerOf
 py::object createGeneralBoundaryConditionOfType(const char* type, py::args args, py::kwargs kw)
 {
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     auto bc = oofem::classFactory.createBoundaryCondition(type,number,domain);
     if (!bc) { OOFEM_RAISE("generalBoundaryCondition: wrong input data"); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -360,7 +379,7 @@ py::object deadWeight(py::args args, py::kwargs kw) { return createGeneralBounda
 py::object createInitialConditionOfType(const char* type, py::args args, py::kwargs kw)
 {
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     auto ic = oofem::classFactory.createInitialCondition(type,number,domain);
     if (!ic) { OOFEM_RAISE("initialCondition: wrong input data"); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -377,7 +396,7 @@ py::object initialCondition(py::args args, py::kwargs kw) { return createInitial
 py::object createMaterialOfType(const char* type, py::args args, py::kwargs kw)
 {
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     auto mat = oofem::classFactory.createMaterial(type,number,domain);
     if (!mat) { OOFEM_RAISE("material: wrong input data"); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -403,7 +422,7 @@ py::object upm(py::args args, py::kwargs kw) { return createMaterialOfType("upm"
 py::object createCrossSectionOfType(const char* type, py::args args, py::kwargs kw)
 {
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     auto cs = oofem::classFactory.createCrossSection(type,number,domain);
     if (!cs) { OOFEM_RAISE("crossSection: wrong input data"); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -422,7 +441,7 @@ py::object simpleTransportCS(py::args args, py::kwargs kw) { return createCrossS
 py::object createLoadTimeFunctionOfType(const char* type, py::args args, py::kwargs kw)
 {
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     auto ltf = oofem::classFactory.createFunction(type,number,domain);
     if (!ltf) { OOFEM_RAISE("function: wrong input data"); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -443,7 +462,7 @@ py::object piecewiseLinFunction(py::args args, py::kwargs kw) { return createLoa
 py::object createExportModuleOfType(const char* type, py::args args, py::kwargs kw)
 {
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::EngngModel *engngModel = len(args)>1? args[1].cast<oofem::EngngModel *>() : nullptr;
+    oofem::EngngModel *engngModel = len(args)>1? PY_CAST(oofem::EngngModel*,args[1]) : nullptr;
     auto module = oofem::classFactory.createExportModule(type,number,engngModel);
     if (!module) { OOFEM_RAISE("exportModule: wrong input data"); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -463,7 +482,7 @@ py::object vtkmemory(py::args args, py::kwargs kw) { return createExportModuleOf
 py::object createSetOfType(const char* type, py::args args, py::kwargs kw)
 {
     int number = len(args)>0?PyLong_AsUnsignedLong(args[0].ptr()):0;
-    oofem::Domain* domain = len(args)>1? args[1].cast<oofem::Domain *>() : nullptr;
+    oofem::Domain* domain = len(args)>1? PY_CAST(oofem::Domain*,args[1]) : nullptr;
     std::unique_ptr<Set> setP = std::make_unique<Set>(number, domain);
     if ( !setP ) { OOFEM_RAISE(("Couldn't create set: "+std::to_string(number)).c_str()); }
     oofem::OOFEMTXTInputRecord ir = makeOOFEMTXTInputRecordFrom(kw);
@@ -513,17 +532,17 @@ py::object createTermOfType(std::string type, py::args args, py::kwargs kw)
 {
     if (type == "BTSigmaTerm") {
         if (len(args)>2) {
-            oofem::Variable * f = args[0].cast<oofem::Variable *>();
-            oofem::Variable * tf = args[1].cast<oofem::Variable *>();
-            oofem::MaterialMode m = args[2].cast<oofem::MaterialMode &>() ;
+            oofem::Variable * f = PY_CAST(oofem::Variable*,args[0]);
+            oofem::Variable * tf = PY_CAST(oofem::Variable*,args[1]);
+            oofem::MaterialMode m = PY_CAST(oofem::MaterialMode,args[2]);
             std::unique_ptr<Term> t = std::make_unique<BTSigmaTerm2>(f, tf, m);
             return py::cast(t.release());
         }
     } else if (type == "NTfTerm") {
         if (len(args)>2) {
-            oofem::Variable * f = args[0].cast<oofem::Variable *>();
-            oofem::Variable * tf = args[1].cast<oofem::Variable *>();
-            oofem::MaterialMode m = args[2].cast<oofem::MaterialMode &>() ;
+            oofem::Variable * f = PY_CAST(oofem::Variable*,args[0]);
+            oofem::Variable * tf = PY_CAST(oofem::Variable*,args[1]);
+            oofem::MaterialMode m = PY_CAST(oofem::MaterialMode,args[2]);
             std::unique_ptr<Term> t = std::make_unique<NTfTerm>(f, tf, m);
             return py::cast(t.release());
         }
@@ -548,8 +567,8 @@ py::object skyline() {
  * Linear sparse solvers
 *************************************************************/
 py::object ldltFactorization(py::args args, py::kwargs kw) {
-    oofem::Domain* domain = len(args)>0? args[0].cast<oofem::Domain *>() : nullptr;
-    oofem::EngngModel *emodel = len(args)>1? args[1].cast<oofem::EngngModel *>() : nullptr;
+    oofem::Domain* domain = len(args)>0? PY_CAST(oofem::Domain*,args[0]) : nullptr;
+    oofem::EngngModel *emodel = len(args)>1? PY_CAST(oofem::EngngModel*,args[1]) : nullptr;
     std::unique_ptr<SparseLinearSystemNM> t = std::make_unique<LDLTFactorization>(domain, emodel);
     return py::cast(t.release()); 
 }

--- a/bindings/python/tests/test_1.py
+++ b/bindings/python/tests/test_1.py
@@ -5,8 +5,10 @@ except: # in-tree
     import oofempy
     import util
 
+import pytest
 
-def test_1():
+@pytest.mark.skipif(oofempy.hasModule('nanobind'),reason='Skipping with nanobind')
+def test_arrays():
     a = oofempy.FloatArray((1.0, 2.0, 3.0))
     b = oofempy.FloatArray((0.0, -1.0, 1.0))
     x = oofempy.FloatArray(3)
@@ -64,4 +66,4 @@ def test_1():
     assert a0[0,2]==99
 
 if __name__ == "__main__":
-    test_1()
+    test_arrays()

--- a/bindings/python/tests/test_1.py
+++ b/bindings/python/tests/test_1.py
@@ -56,5 +56,12 @@ def test_1():
     assert (round(y[2]-3.0, 6) == 0)
     print(y)
 
+    # test that asNumpyArray return view to the original data
+    a0=oofempy.FloatMatrix(3,3)
+    a1=a0.asNumpyArray()
+    a1[0,2]=99
+    assert a1[0,2]==a0[0,2]
+    assert a0[0,2]==99
+
 if __name__ == "__main__":
     test_1()

--- a/bindings/python/tests/test_3.py
+++ b/bindings/python/tests/test_3.py
@@ -8,6 +8,7 @@ try: # installed
 except: # in-tree
     import oofempy
     import util
+import numpy as np
 
 
 class MyFunc(oofempy.Function):
@@ -87,7 +88,7 @@ def test_3():
     # elements
     #e1 = oofempy.truss1d(1, domain, nodes=(1,n2),  mat=1,   crossSect=1)
     e1 = MyElement(1, domain)
-    e1.setDofManagers((1,2))
+    e1.setDofManagers(np.array([1,2]))
     # construct OOFEMTXTInputRecord from bp::dict **kw
     ir = oofempy.OOFEMTXTInputRecord()
     ir.setRecordString ("nodes 2 1 2 mat 1 crosssect 1")

--- a/bindings/python/tests/test_5.py
+++ b/bindings/python/tests/test_5.py
@@ -7,12 +7,13 @@ except: # in-tree
     import oofempy
     import util
 
+import numpy as np
 
 #Function returning temperature.
 def evalField(coords, mode, tStep):
     val = 10.*tStep.giveNumber()*coords[0]
     print("Evaluating field at %f,%f. Assigning temperature %f" % (coords[0], coords[1], val))
-    return (val,) #Return list of len 1
+    return np.array([val,]) #Return list of len 1
 
 
 def test_5():
@@ -103,8 +104,10 @@ def test_5():
     v3 = problem.giveUnknownComponent(oofempy.ValueModeType.VM_Total, problem.giveCurrentStep(False), domain, domain.giveDofManager(3).giveDofWithID(oofempy.DofIDItem.D_v))
     assert (round (v3-4.608e-4, 8) == 0), "Node 3 dof 2 displacement check failed"
     
-    
-    t1 = temperature[0][0]
+    try:
+        t1 = temperature[0][0] # np.array
+    except TypeError:
+        t1 = temperature[0,0]  # FloatMatrix
     assert (round (t1-48.0000, 4) == 0), "Export of primary field failed"
     
     problem.terminateAnalysis()

--- a/src/oofemlib/dofmanvalfield.h
+++ b/src/oofemlib/dofmanvalfield.h
@@ -47,11 +47,6 @@
 #include "mmashapefunctprojection.h"
 #include "cltypes.h"
 
-#ifdef _PYBIND_BINDINGS
-    #include <pybind11/pybind11.h>
-    #include <pybind11/stl.h>//Conversion for lists
-    namespace py = pybind11;
-#endif
 
     
 namespace oofem {

--- a/src/oofemlib/exportregion.C
+++ b/src/oofemlib/exportregion.C
@@ -176,31 +176,31 @@ ExportRegion::clear()
     this->nodeVarsFromXFEMIS.clear();
 }
 
-#ifdef _PYBIND_BINDINGS
 
-py::array_t<double>
+FloatMatrix
 ExportRegion::getVertices () {
-  double* result = new double[this->numNodes*3];
+  FloatMatrix result(this->numNodes,3);
   for (int i=0; i<this->numNodes; i++) {
     FloatArray &c = this->giveNodeCoords(i+1);
     for (int j=0; j<c.giveSize(); j++) {
-      result[i*3+j]=c[j];
+      result(i,j)=c[j];
     }
     for (int j=c.giveSize(); j<3; j++) {
-      result[i*3+j] = 0.0;
+      result(i,j) = 0.0;
     }
   }
-  return py::array_t<double>(std::vector<ptrdiff_t>{this->numNodes, 3}, &result[0]);
+  return result;
 }
 
-py::array_t<int>
+
+IntArray
 ExportRegion::getCellConnectivity () {
   int reqSize = 0;
   for (int i=0; i<this->numCells; i++) {
     reqSize++;
     reqSize+=this->giveCellConnectivity(i+1).giveSize();
   }
-  int* result = new int[reqSize];
+  IntArray result(reqSize);
   int pos=0;
   for (int i=0; i<this->numCells; i++) {
     IntArray &c = this->giveCellConnectivity(i+1);
@@ -210,84 +210,79 @@ ExportRegion::getCellConnectivity () {
       result[pos++]=c[i]-1;
     }
   }
-  return py::array_t<int>(reqSize, result);
+  return result;
 }
 
-py::array_t<int>
+IntArray
 ExportRegion::getCellTypes () {
-  int* result = new int[this->numCells];
+  IntArray result(this->numCells);
   for (int i=0; i<this->numCells; i++) {
     result[i]=this->giveCellType(i+1); // m.giveCellType(this->regionElInd.at(i+1));
   }
-  return py::array_t<int>(this->numCells, result);     
+  return result;
 }
 
-py::array_t<double>
-ExportRegion::getPrimaryVertexValues (UnknownType u) {
 
+
+FloatMatrix
+ExportRegion::getPrimaryVertexValues (UnknownType u) {
   if (this->nodeVars.find(u) != this->nodeVars.end()) {
     // key exists
     std::vector<FloatArray>& nodalVars = this->nodeVars[u];
     // get size of nodal record
-    int recSize = nodalVars[0].giveSize();    
-    double* result = new double[this->numNodes*recSize];
-    int counter = 0;
+    int recSize = nodalVars[0].giveSize();
+    FloatMatrix result(this->numNodes,recSize);
     for (int i=0;i<this->numNodes; i++) {
       FloatArray& v = nodalVars[i];
       for (int j=0; j<recSize; j++) {
-        result[counter++]=v[j];
+        result(i,j)=v[j];
       }
     }
-    return py::array_t<double>(std::vector<ptrdiff_t>{this->numNodes, recSize}, result);
-    //return py::array_t<double>(this->numNodes*recSize, result);     
+    return result;
   } else {
-    return py::array_t<double>(0);
+    return FloatMatrix(0,0);
   }
 }
 
-py::array_t<double>
+FloatMatrix
 ExportRegion::getInternalVertexValues(InternalStateType u) {
   if (this->nodeVarsFromIS.find(u)!=this->nodeVarsFromIS.end()) {
     // key exists
     std::vector<FloatArray>& nodalVars = this->nodeVarsFromIS[u];
     // get size of nodal record
     int recSize = nodalVars[0].giveSize();
-    double* result = new double[this->numNodes*recSize];
-    int counter = 0;
+    FloatMatrix result(this->numNodes,recSize);
     for (int i=0;i<this->numNodes; i++) {
       FloatArray& v = nodalVars[i];
       for (int j=0; j<recSize; j++) {
-        result[counter++]=v[j];
+        result(i,j)=v[j];
       }
     }
-    return py::array_t<double>(std::vector<ptrdiff_t>{this->numNodes, recSize}, result);
+    return result;
   } else {
-    return py::array_t<double>(0);   
+    return FloatMatrix(0,0);
   }
 }
   
-py::array_t<double>
+FloatMatrix
 ExportRegion::getCellValues(InternalStateType u) {
   if (this->cellVars.find(u)!=this->cellVars.end()) {
     // key exists
     std::vector<FloatArray>& cv = this->cellVars[u];
     // get size of nodal record
     int recSize = cv[0].giveSize();
-    double* result = new double[this->numCells*recSize];
-    int counter = 0;
+    FloatMatrix result(this->numCells,recSize);
     for (int i=0;i<this->numCells; i++) {
       FloatArray& v = cv[i];
       for (int j=0; j<recSize; j++) {
-        result[counter++]=v[j];
+        result(i,j)=v[j];
       }
     }
-    return py::array_t<double>(std::vector<ptrdiff_t>{this->numCells, recSize}, result);
+    return result;
   } else {
-    return py::array_t<double>(0);   
+    return FloatMatrix(0,0);
   }
 }
-
-#endif
 
 
 } // end namespace oofem

--- a/src/oofemlib/exportregion.h
+++ b/src/oofemlib/exportregion.h
@@ -43,12 +43,6 @@
 #include "element.h"
 
 
-#ifdef _PYBIND_BINDINGS
- #include <pybind11/pybind11.h>
- #include <pybind11/stl.h>   //Conversion for lists
- #include "pybind11/numpy.h"
-namespace py = pybind11;
-#endif
 
 #include <string>
 #include <list>
@@ -137,15 +131,13 @@ public:
     //void setRegionCells(IntArray& cells) {this->regionElInd = cells;}
     IntArray& getRegionCells () {return this->regionElInd;}
 
-#ifdef _PYBIND_BINDINGS
-    py::array_t<double> getVertices () ;
-    py::array_t<int> getCellConnectivity ();
-    py::array_t<int> getCellTypes ();
-    py::array_t<double> getPrimaryVertexValues (UnknownType u);
-    py::array_t<double> getInternalVertexValues(InternalStateType u);
-    py::array_t<double> getCellValues(InternalStateType u);
+    FloatMatrix getVertices () ;
+    IntArray getCellConnectivity ();
+    IntArray getCellTypes ();
+    FloatMatrix getPrimaryVertexValues (UnknownType u);
+    FloatMatrix getInternalVertexValues(InternalStateType u);
+    FloatMatrix getCellValues(InternalStateType u);
 
-#endif
 
 private:
     int numCells;

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -96,6 +96,9 @@ public:
     std::vector< double > :: const_iterator end() const { return this->values.end(); }
     //@}
 
+    static constexpr int Dim = 1;
+    typedef double Scalar;
+
     /// Constructor for sized array. Data is zeroed.
     FloatArray(int n = 0) : values(n) { }
     /// Disallow double parameter, which can otherwise give unexpected results.

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -107,6 +107,9 @@ public:
     std::vector< double > :: const_iterator end() const { return this->values.end(); }
     //@}
 
+    constexpr static int Dim = 2;
+    typedef double Scalar;
+
     /**
      * Creates matrix of given size.
      * @param n Number of rows.

--- a/src/oofemlib/intarray.h
+++ b/src/oofemlib/intarray.h
@@ -74,6 +74,9 @@ public:
     std::vector< int > :: const_iterator end() const { return this->values.end(); }
     //@}
 
+    constexpr static int Dim = 1;
+    typedef int Scalar;
+
     /// Constructor for sized array. Data is zeroed.
     IntArray(int n = 0) : values(n) { }
     /// Copy constructor. Creates the array from another array.

--- a/src/oofemlib/pythonfield.C
+++ b/src/oofemlib/pythonfield.C
@@ -32,15 +32,20 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-//#include <Python.h>
-#include <pybind11/embed.h>
+#ifdef _USE_NANOBIND
+    #include<nanobind/nanobind.h>
+#else
+    #include <pybind11/embed.h>
+    namespace py = pybind11;
+#endif
+
 
 #include "field.h"
 #include "pythonfield.h"
 #include "floatarray.h"
 #include "timestep.h"
 
-namespace py = pybind11;
+
 
 namespace oofem {
 // REGISTER_Material(PythonField);
@@ -71,10 +76,17 @@ int PythonField :: evaluateAt(FloatArray &answer, const FloatArray &coords, Valu
     // py::scoped_interpreter guard{}; // start the interpreter and keep it alive
     
 //     py::initialize_interpreter();
-    
-    py::module calc = py::module::import(moduleName.c_str());
-    py::object result = calc.attr(functionName.c_str())(coords, mode, tStep);
-    answer = result.cast<FloatArray>();
+    #ifdef _USE_NANOBIND
+        nanobind::module_ calc = nanobind::module_::import_(moduleName.c_str());
+        nanobind::object result = calc.attr(functionName.c_str())(coords, mode, tStep);
+        answer = nanobind::cast<FloatArray>(result);
+    #else
+        py::module calc = py::module::import(moduleName.c_str());
+        py::object result = calc.attr(functionName.c_str())(coords, mode, tStep);
+        answer = result.cast<FloatArray>();
+    #endif
+
+
 //     py::finalize_interpreter();
     
     return 0;

--- a/src/oofemlib/pythonfield.C
+++ b/src/oofemlib/pythonfield.C
@@ -34,6 +34,9 @@
 
 #ifdef _USE_NANOBIND
     #include<nanobind/nanobind.h>
+    // must include converters here so that compiler can pickup template specialization for arrays
+    #include"../../bindings/python/oofemarray-nanobind.h"
+    namespace nb = nanobind;
 #else
     #include <pybind11/embed.h>
     namespace py = pybind11;
@@ -67,7 +70,6 @@ void PythonField :: setModuleName(std::string moduleName){
     //this->moduleName.resize(this->moduleName.size()); //remove trailing quotes
 }
 
-
 int PythonField :: evaluateAt(FloatArray &answer, const FloatArray &coords, ValueModeType mode, TimeStep *tStep)
 {
     // Do not use the raw CPython API functions Py_Initialize and Py_Finalize as these do not properly handle the lifetime of pybind11’s internal data.
@@ -77,9 +79,9 @@ int PythonField :: evaluateAt(FloatArray &answer, const FloatArray &coords, Valu
     
 //     py::initialize_interpreter();
     #ifdef _USE_NANOBIND
-        nanobind::module_ calc = nanobind::module_::import_(moduleName.c_str());
-        nanobind::object result = calc.attr(functionName.c_str())(coords, mode, tStep);
-        answer = nanobind::cast<FloatArray>(result);
+        nb::module_ calc = nb::module_::import_(moduleName.c_str());
+        nb::object result = calc.attr(functionName.c_str())(nb::cast(coords), nb::cast(mode), nb::cast(tStep));
+        answer = nb::cast<FloatArray>(result);
     #else
         py::module calc = py::module::import(moduleName.c_str());
         py::object result = calc.attr(functionName.c_str())(coords, mode, tStep);

--- a/src/oofemlib/vtkbaseexportmodule.h
+++ b/src/oofemlib/vtkbaseexportmodule.h
@@ -48,13 +48,6 @@
 #include <fstream>
 #include <iomanip>
 
-#ifdef _PYBIND_BINDINGS
- #include <pybind11/pybind11.h>
- #include <pybind11/stl.h>   //Conversion for lists
- #include "pybind11/numpy.h"
-namespace py = pybind11;
-#endif
-
 #ifdef _WIN32
  #define NULL_DEVICE "NUL:"
 #else

--- a/src/oofemlib/vtkhdf5exportmodule.h
+++ b/src/oofemlib/vtkhdf5exportmodule.h
@@ -47,13 +47,6 @@
 #include <iomanip>
 
 
-#ifdef _PYBIND_BINDINGS
- #include <pybind11/pybind11.h>
- #include <pybind11/stl.h>   //Conversion for lists
- #include "pybind11/numpy.h"
-namespace py = pybind11;
-#endif
-
 #ifdef _WIN32
  #define NULL_DEVICE "NUL:"
 #else

--- a/src/oofemlib/vtkmemoryexportmodule.h
+++ b/src/oofemlib/vtkmemoryexportmodule.h
@@ -43,13 +43,6 @@
 #include <fstream>
 #include <iomanip>
 
-#ifdef _PYBIND_BINDINGS
- #include <pybind11/pybind11.h>
- #include <pybind11/stl.h>   //Conversion for lists
- #include "pybind11/numpy.h"
-namespace py = pybind11;
-#endif
-
 #ifdef _WIN32
  #define NULL_DEVICE "NUL:"
 #else

--- a/src/oofemlib/vtkxmlexportmodule.h
+++ b/src/oofemlib/vtkxmlexportmodule.h
@@ -51,12 +51,6 @@
  #include <vtkSmartPointer.h>
 #endif
 
-#ifdef _PYBIND_BINDINGS
- #include <pybind11/pybind11.h>
- #include <pybind11/stl.h>   //Conversion for lists
- #include "pybind11/numpy.h"
-namespace py = pybind11;
-#endif
 
 #ifdef _WIN32
  #define NULL_DEVICE "NUL:"


### PR DESCRIPTION
Nanobind now converts `Float{Matrix,Array}` and `IntArray` from/to numpy.array, bidirectionally. The downside is that plain python lists as function parameters where e.g. FloatArray (such as `[1.1,2.2,3.3]`) won't be accepted and must be written as `np.array([1.1,2.2,3.3]))`; ongoing discussion about such possible implicit conversion with nanobind is happening [here](https://github.com/wjakob/nanobind/discussions/327).

Nanobind can optionally support stable python 3 api (unsupported by pybind11) for module compatible across major python version. As long as both pybind11 and nanobind can be supported in parallel (via some `#ifdef`s and others), both can be kept in the source and then a decision made.

Not all tests work with nanobind (yet) due to the necessity of passing `np.array` objects instead of sequences.

Having the same functionality (casting between oofem matrices/arrays and np.array) with pybind11 seems to be quite a bit more involved, and that will be done later (perhaps).

