### PR TITLE
numerical clean-up (partial)

### DIFF
--- a/bindings/python/oofem.cpp
+++ b/bindings/python/oofem.cpp
@@ -839,6 +839,7 @@ PYBIND11_MODULE(oofempy, m) {
         .def("assemble", &oofem::FloatArray::assemble)
         .def("distance", (double (oofem::FloatArray::*)(const oofem::FloatArray &) const) &oofem::FloatArray::distance)
         .def("normalize", &oofem::FloatArray::normalize)
+        .def("normalize_giveNorm", &oofem::FloatArray::normalize_giveNorm)
         .def("computeNorm", &oofem::FloatArray::computeNorm)
         .def("product", &oofem::FloatArray::product)
         .def("zero", &oofem::FloatArray::zero)

--- a/src/mpm/mpm.h
+++ b/src/mpm/mpm.h
@@ -486,7 +486,7 @@ class MPElement : public Element {
             this->giveInternalDofManager(i)->giveUnknownVector(uloc, dofs, mode, tstep);
             ans.insert(ans.end(),uloc.begin(),uloc.end());
         }
-        answer = FloatArray(ans.begin(),ans.end());
+        answer = FloatArray::fromVector(ans);
     }
 
   virtual double computeSurfaceVolumeAround(GaussPoint* igp, int iSurf) 

--- a/src/mpm/mpm.h
+++ b/src/mpm/mpm.h
@@ -428,15 +428,12 @@ class MPElement : public Element {
         } else {
             bNodes = this->giveBoundaryEdgeNodes(ibc);
         }
-        int num = 0;
-        for (int i: bNodes){ this->giveDofManager(i)->giveUnknownVector(uloc, dofs, mode, tStep); num+=uloc.size(); }
-        answer.resize(num);
-        int offset=0;
+        std::list<double> ans;
         for (int i : bNodes) {
             this->giveDofManager(i)->giveUnknownVector(uloc, dofs, mode, tStep);
-            answer.copySubVector(uloc,offset+1);
-            offset+=uloc.size();
+            for(const double& u: uloc){ ans.push_back(u); }
         }
+        answer=FloatArray::fromList(ans);
     }
   
     /// @brief  Assembles the partial element contribution into local element matrix

--- a/src/mpm/mpmsemodels.h
+++ b/src/mpm/mpmsemodels.h
@@ -212,8 +212,8 @@ namespace oofem {
         // returns unknown quantity like displacement, velocity of equation eq
         // This function translates this request to numerical method language
         {
-            int eq = dof->__giveEquationNumber();
         #ifdef DEBUG
+            int eq = dof->__giveEquationNumber();
             if ( eq == 0 ) {
                 OOFEM_ERROR("invalid equation number");
             }

--- a/src/mpm/termlibrary3.C
+++ b/src/mpm/termlibrary3.C
@@ -71,10 +71,7 @@ void TMBTSigTerm::computeTMgeneralizedStrain (FloatArray& answer, FloatMatrix& B
     // evaluate temperature at given point
     this->temperatureField->interpolation->evalN(Nt, lcoords, FEIElementGeometryWrapper(&cell));
     double t = Nt.dotProduct(rt);
-    answer.resize(Bu.size()+gradT.size()+1);
-    answer.copySubVector(Bu,1);
-    answer.copySubVector(gradT,Bu.size()+1); // construct generalized strain vector
-    answer.at(Bu.size()+gradT.size()+1)=t; // add temperature
+    answer=FloatArray::fromConcatenated({Bu,gradT,Vec1(t)});
 }
 
 TMgNTfTerm::TMgNTfTerm (const Variable *testField, const Variable* unknownField, MatResponseMode lhsType, MatResponseMode rhsType) : gNTfTerm(testField, unknownField, lhsType, rhsType) {}

--- a/src/mpm/termlibrary3.C
+++ b/src/mpm/termlibrary3.C
@@ -57,10 +57,10 @@ void TMBTSigTerm::evaluate (FloatArray& answer, MPElement& cell, GaussPoint* gp,
 void TMBTSigTerm::computeTMgeneralizedStrain (FloatArray& answer, FloatMatrix& B, MPElement& cell, const FloatArray& lcoords, MaterialMode mmode, TimeStep* tstep) const {
     FloatArray u, gradT;
     FloatMatrix dndx ;
-    answer.resize(0);
     cell.getUnknownVector(u, this->field, VM_TotalIntrinsic, tstep);
     this->grad(B, this->field, this->field->interpolation, cell, lcoords, mmode);
-    answer.beProductOf(B, u);
+    FloatArray Bu;
+    Bu.beProductOf(B, u);
 
     FloatArray rt, Nt;
     cell.getUnknownVector(rt, temperatureField, VM_TotalIntrinsic, tstep);
@@ -71,8 +71,10 @@ void TMBTSigTerm::computeTMgeneralizedStrain (FloatArray& answer, FloatMatrix& B
     // evaluate temperature at given point
     this->temperatureField->interpolation->evalN(Nt, lcoords, FEIElementGeometryWrapper(&cell));
     double t = Nt.dotProduct(rt);
-    answer.append(gradT); // construct generalized strain vector
-    answer.append(t); // add temperature
+    answer.resize(Bu.size()+gradT.size()+1);
+    answer.copySubVector(Bu,1);
+    answer.copySubVector(gradT,Bu.size()+1); // construct generalized strain vector
+    answer.at(Bu.size()+gradT.size()+1)=t; // add temperature
 }
 
 TMgNTfTerm::TMgNTfTerm (const Variable *testField, const Variable* unknownField, MatResponseMode lhsType, MatResponseMode rhsType) : gNTfTerm(testField, unknownField, lhsType, rhsType) {}

--- a/src/oofemlib/element.C
+++ b/src/oofemlib/element.C
@@ -66,6 +66,7 @@
 #endif
 
 #include <cstdio>
+#include <cassert>
 
 namespace oofem {
 Element :: Element(int n, Domain *aDomain) :
@@ -91,19 +92,22 @@ Element :: computeVectorOf(ValueModeType u, TimeStep *tStep, FloatArray &answer)
     FloatMatrix G2L;
     FloatArray vec;
 
-    answer.reserve( this->computeNumberOfGlobalDofs() );
-
+    answer.resize( this->computeNumberOfGlobalDofs() );
+    int offset=0;
     for ( int i = 1; i <= this->giveNumberOfDofManagers(); i++ ) {
         this->giveDofManDofIDMask(i, dofIDMask);
         this->giveDofManager(i)->giveUnknownVector(vec, dofIDMask, u, tStep, true);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
 
     for ( int i = 1; i <= giveNumberOfInternalDofManagers(); i++ ) {
         this->giveInternalDofManDofIDMask(i, dofIDMask);
         this->giveInternalDofManager(i)->giveUnknownVector(vec, dofIDMask, u, tStep, true);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
+    assert(offset==(int)answer.size());
 
     if ( this->computeGtoLRotationMatrix(G2L) ) {
         answer.rotatedWith(G2L, 'n');
@@ -117,17 +121,21 @@ Element :: computeVectorOf(const IntArray &dofIDMask, ValueModeType u, TimeStep 
     FloatMatrix G2L;
     FloatArray vec;
 
-    answer.reserve( dofIDMask.giveSize() * ( this->giveNumberOfDofManagers() + this->giveNumberOfInternalDofManagers() ) );
+    answer.resize( dofIDMask.giveSize() * ( this->giveNumberOfDofManagers() + this->giveNumberOfInternalDofManagers() ) );
+    int offset=0;
 
     for ( int i = 1; i <= this->giveNumberOfDofManagers(); i++ ) {
         this->giveDofManager(i)->giveUnknownVector(vec, dofIDMask, u, tStep, padding);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
 
     for ( int i = 1; i <= giveNumberOfInternalDofManagers(); i++ ) {
         this->giveInternalDofManager(i)->giveUnknownVector(vec, dofIDMask, u, tStep, padding);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
+    assert(offset==(int)answer.size());
 
     ///@todo This rotation matrix needs to have the dofidmask/eid/primary field or something passed to it, otherwise it won't work generally.
     if ( this->computeGtoLRotationMatrix(G2L) ) {
@@ -143,12 +151,15 @@ Element :: computeBoundaryVectorOf(const IntArray &bNodes, const IntArray &dofID
     FloatMatrix G2L;
     FloatArray vec;
 
-    answer.reserve( dofIDMask.giveSize() * bNodes.giveSize() );
+    answer.resize( dofIDMask.giveSize() * bNodes.giveSize() );
+    int offset=0;
 
     for ( int bNode: bNodes ) {
         this->giveDofManager( bNode )->giveUnknownVector(vec, dofIDMask, u, tStep, padding);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
+    assert(offset==(int)answer.size());
 
     if ( this->computeGtoLRotationMatrix(G2L) ) {
         OOFEM_ERROR("Local coordinate system is not implemented yet");
@@ -161,17 +172,21 @@ Element :: computeVectorOf(PrimaryField &field, const IntArray &dofIDMask, Value
 {
     FloatMatrix G2L;
     FloatArray vec;
-    answer.reserve( this->computeNumberOfGlobalDofs() );
+    answer.resize( this->computeNumberOfGlobalDofs() );
+    int offset=0;
 
     for ( int i = 1; i <= this->giveNumberOfDofManagers(); i++ ) {
         this->giveDofManager(i)->giveUnknownVector(vec, dofIDMask, field, u, tStep);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
 
     for ( int i = 1; i <= giveNumberOfInternalDofManagers(); i++ ) {
         this->giveInternalDofManager(i)->giveUnknownVector(vec, dofIDMask, field, u, tStep);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
+    assert(offset==(int)answer.size());
 
     if ( this->computeGtoLRotationMatrix(G2L) ) {
         answer.rotatedWith(G2L, 'n');
@@ -186,19 +201,23 @@ Element :: computeVectorOfPrescribed(ValueModeType u, TimeStep *tStep, FloatArra
     FloatMatrix G2L;
     FloatArray vec;
 
-    answer.reserve( this->computeNumberOfGlobalDofs() );
+    answer.resize( this->computeNumberOfGlobalDofs() );
+    int offset=0;
 
     for ( int i = 1; i <= this->giveNumberOfDofManagers(); i++ ) {
         this->giveDofManDofIDMask(i, dofIDMask);
         this->giveDofManager(i)->givePrescribedUnknownVector(vec, dofIDMask, u, tStep);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
 
     for ( int i = 1; i <= giveNumberOfInternalDofManagers(); i++ ) {
         this->giveInternalDofManDofIDMask(i, dofIDMask);
 	this->giveInternalDofManager(i)->givePrescribedUnknownVector(vec, dofIDMask, u, tStep);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
+    assert(offset==(int)answer.size());
 
     if ( this->computeGtoLRotationMatrix(G2L) ) {
         answer.rotatedWith(G2L, 'n');
@@ -213,17 +232,21 @@ Element :: computeVectorOfPrescribed(const IntArray &dofIDMask, ValueModeType mo
     FloatMatrix G2L;
     FloatArray vec;
 
-    answer.reserve( dofIDMask.giveSize() * this->computeNumberOfGlobalDofs() );
+    answer.resize( dofIDMask.giveSize() * this->computeNumberOfGlobalDofs() );
+    int offset=0;
 
     for ( int i = 1; i <= this->giveNumberOfDofManagers(); i++ ) {
         this->giveDofManager(i)->givePrescribedUnknownVector(vec, dofIDMask, mode, tStep);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
 
     for ( int i = 1; i <= giveNumberOfInternalDofManagers(); i++ ) {
         this->giveInternalDofManager(i)->givePrescribedUnknownVector(vec, dofIDMask, mode, tStep);
-        answer.append(vec);
+        answer.copySubVector(vec,offset+1);
+        offset+=vec.size();
     }
+    assert(offset==(int)answer.size());
 
     if ( this->computeGtoLRotationMatrix(G2L) ) {
         answer.rotatedWith(G2L, 'n');

--- a/src/oofemlib/fei2dlineconst.C
+++ b/src/oofemlib/fei2dlineconst.C
@@ -97,7 +97,7 @@ double FEI2dLineConst :: edgeEvalNormal(FloatArray &normal, int iedge, const Flo
     normal.resize(2);
     normal.at(1) = cellgeo.giveVertexCoordinates(2).at(yind) - cellgeo.giveVertexCoordinates(1).at(yind);
     normal.at(2) = -( cellgeo.giveVertexCoordinates(2).at(xind) - cellgeo.giveVertexCoordinates(1).at(xind) );
-    return normal.normalize() * 0.5;
+    return normal.normalize_giveNorm() * 0.5;
 }
 
 double FEI2dLineConst :: giveTransformationJacobian(const FloatArray &lcoords, const FEICellGeometry &cellgeo) const

--- a/src/oofemlib/fei2dlinehermite.C
+++ b/src/oofemlib/fei2dlinehermite.C
@@ -68,7 +68,7 @@ double FEI2dLineHermite :: evaldNdx(FloatMatrix &answer, const FloatArray &lcoor
     FloatArray vec(2);
     vec.at(1) = cellgeo.giveVertexCoordinates(2).at(xind) - cellgeo.giveVertexCoordinates(1).at(xind);
     vec.at(2) = cellgeo.giveVertexCoordinates(2).at(yind) - cellgeo.giveVertexCoordinates(1).at(yind);
-    double detJ = vec.normalize() * 0.5;
+    double detJ = vec.normalize_giveNorm() * 0.5;
 
     answer.beDyadicProductOf(dNds, vec);
     return detJ;
@@ -131,7 +131,7 @@ double FEI2dLineHermite :: edgeEvalNormal(FloatArray &normal, int iedge, const F
     normal.at(1) = cellgeo.giveVertexCoordinates(2).at(yind) - cellgeo.giveVertexCoordinates(1).at(yind);
     normal.at(2) = -( cellgeo.giveVertexCoordinates(2).at(xind) - cellgeo.giveVertexCoordinates(1).at(xind) );
 
-    return normal.normalize() * 0.5;
+    return normal.normalize_giveNorm() * 0.5;
 }
 
 double FEI2dLineHermite :: giveTransformationJacobian(const FloatArray &lcoords, const FEICellGeometry &cellgeo) const 

--- a/src/oofemlib/fei2dlinelin.C
+++ b/src/oofemlib/fei2dlinelin.C
@@ -120,7 +120,7 @@ double FEI2dLineLin :: edgeEvalNormal(FloatArray &normal, int iedge, const Float
     normal.resize(2);
     normal.at(1) = cellgeo.giveVertexCoordinates(2).at(yind) - cellgeo.giveVertexCoordinates(1).at(yind);
     normal.at(2) = -( cellgeo.giveVertexCoordinates(2).at(xind) - cellgeo.giveVertexCoordinates(1).at(xind) );
-    return normal.normalize() * 0.5;
+    return normal.normalize_giveNorm() * 0.5;
 }
 
 double FEI2dLineLin :: giveTransformationJacobian(const FloatArray &lcoords, const FEICellGeometry &cellgeo) const

--- a/src/oofemlib/fei2dlinequad.C
+++ b/src/oofemlib/fei2dlinequad.C
@@ -184,7 +184,7 @@ double FEI2dLineQuad :: edgeEvalNormal(FloatArray &normal, int iedge, const Floa
                    - dN2dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(2) ).at(xind) +
                    - dN3dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(3) ).at(xind);
 
-    return normal.normalize();
+    return normal.normalize_giveNorm();
 }
 
 void FEI2dLineQuad :: edgeLocal2global(FloatArray &answer, int iedge,

--- a/src/oofemlib/fei2dquadlin.C
+++ b/src/oofemlib/fei2dquadlin.C
@@ -270,7 +270,7 @@ FEI2dQuadLin :: edgeEvalNormal(FloatArray &answer, int iedge, const FloatArray &
         cellgeo.giveVertexCoordinates(nodeB).at(yind) - cellgeo.giveVertexCoordinates(nodeA).at(yind),
         cellgeo.giveVertexCoordinates(nodeA).at(xind) - cellgeo.giveVertexCoordinates(nodeB).at(xind)
     };
-    return answer.normalize() * 0.5;
+    return answer.normalize_giveNorm() * 0.5;
 }
 
 void

--- a/src/oofemlib/fei2dquadquad.C
+++ b/src/oofemlib/fei2dquadquad.C
@@ -340,7 +340,7 @@ double FEI2dQuadQuad :: edgeEvalNormal(FloatArray &normal, int iedge, const Floa
                    - dN2dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(2) ).at(xind) +
                    - dN3dxi * cellgeo.giveVertexCoordinates( edgeNodes.at(3) ).at(xind);
 
-    return normal.normalize();
+    return normal.normalize_giveNorm();
 }
 
 

--- a/src/oofemlib/fei2dtrlin.C
+++ b/src/oofemlib/fei2dtrlin.C
@@ -227,7 +227,7 @@ double FEI2dTrLin :: edgeEvalNormal(FloatArray &normal, int iedge, const FloatAr
         cellgeo.giveVertexCoordinates( edgeNodes.at(2) ).at(yind) - cellgeo.giveVertexCoordinates( edgeNodes.at(1) ).at(yind),
         cellgeo.giveVertexCoordinates( edgeNodes.at(1) ).at(xind) - cellgeo.giveVertexCoordinates( edgeNodes.at(2) ).at(xind)
     };
-    return normal.normalize() * 0.5;
+    return normal.normalize_giveNorm() * 0.5;
 }
 
 void

--- a/src/oofemlib/fei2dtrquad.C
+++ b/src/oofemlib/fei2dtrquad.C
@@ -280,7 +280,7 @@ double FEI2dTrQuad :: edgeEvalNormal(FloatArray &normal, int iedge, const FloatA
                    - dN2dxi *cellgeo.giveVertexCoordinates( edgeNodes.at(2) ).at(xind) +
                    - dN3dxi *cellgeo.giveVertexCoordinates( edgeNodes.at(3) ).at(xind);
 
-    return normal.normalize();
+    return normal.normalize_giveNorm();
 }
 
 void

--- a/src/oofemlib/fei3dhexalin.C
+++ b/src/oofemlib/fei3dhexalin.C
@@ -554,7 +554,7 @@ FEI3dHexaLin :: surfaceEvalNormal(FloatArray &answer, int isurf, const FloatArra
     }
 
     answer.beVectorProductOf(a, b);
-    return answer.normalize() * 0.0625;
+    return answer.normalize_giveNorm() * 0.0625;
 }
 
 double

--- a/src/oofemlib/fei3dhexaquad.C
+++ b/src/oofemlib/fei3dhexaquad.C
@@ -561,7 +561,7 @@ FEI3dHexaQuad :: surfaceEvalNormal(FloatArray &answer, int isurf, const FloatArr
     }
 
     answer.beVectorProductOf(a, b);
-    return answer.normalize();
+    return answer.normalize_giveNorm();
 }
 
 void

--- a/src/oofemlib/fei3dhexatriquad.C
+++ b/src/oofemlib/fei3dhexatriquad.C
@@ -229,7 +229,7 @@ FEI3dHexaTriQuad :: surfaceEvalNormal(FloatArray &answer, int isurf, const Float
     }
 
     answer.beVectorProductOf(e1, e2);
-    return answer.normalize();
+    return answer.normalize_giveNorm();
 }
 
 

--- a/src/oofemlib/fei3dtetlin.C
+++ b/src/oofemlib/fei3dtetlin.C
@@ -420,7 +420,7 @@ FEI3dTetLin :: surfaceEvalNormal(FloatArray &answer, int isurf, const FloatArray
     b.beDifferenceOf( cellgeo.giveVertexCoordinates( snodes.at(3) ), cellgeo.giveVertexCoordinates( snodes.at(1) ) );
     answer.beVectorProductOf(a, b);
 
-    return answer.normalize();
+    return answer.normalize_giveNorm();
 }
 
 double

--- a/src/oofemlib/fei3dtetquad.C
+++ b/src/oofemlib/fei3dtetquad.C
@@ -551,7 +551,7 @@ FEI3dTetQuad :: surfaceEvalNormal(FloatArray &answer, int isurf, const FloatArra
         b.add( dNdeta[i], cellgeo.giveVertexCoordinates( snodes[i] ) );
     }
     answer.beVectorProductOf(a, b);
-    return answer.normalize();
+    return answer.normalize_giveNorm();
 }
 
 double

--- a/src/oofemlib/fei3dwedgequad.C
+++ b/src/oofemlib/fei3dwedgequad.C
@@ -543,7 +543,7 @@ FEI3dWedgeQuad :: surfaceEvalNormal(FloatArray &answer, int isurf, const FloatAr
     }
 
     answer.beVectorProductOf(a, b);
-    return answer.normalize();
+    return answer.normalize_giveNorm();
 }
 
 

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -51,12 +51,14 @@
 #include <fstream>
 #include <iomanip>
 
-#define FAST_RESIZE(newsize) \
+namespace oofem{
+void FloatArray::_resize_internal(int newsize){
     if ( (newsize) < this->size() ) { \
         this->values.resize((newsize)); \
     } else if ( (newsize) > this->size() ) { \
         this->values.assign((newsize), 0.); \
     }
+}};
 
 #ifdef __LAPACK_MODULE
 extern "C" {
@@ -84,7 +86,7 @@ bool FloatArray :: isAllFinite() const
 void
 FloatArray :: beScaled(double s, const FloatArray &b)
 {
-    FAST_RESIZE(b.size());
+    _resize_internal(b.size());
 
     for ( std::size_t i = 0; i < this->size(); ++i ) {
         (*this) [ i ] = s * b [ i ];
@@ -203,7 +205,7 @@ void FloatArray :: subtract(const FloatArray &src)
     }
 
     if ( this->isEmpty() ) {
-        FAST_RESIZE(src.size());
+        _resize_internal(src.size());
         for ( std::size_t i = 0; i < this->size(); ++i ) {
             (*this) [ i ] = -src [ i ];
         }
@@ -243,7 +245,7 @@ void FloatArray :: beMaxOf(const FloatArray &a, const FloatArray &b)
 
 #  endif
 
-    FAST_RESIZE(n);
+    _resize_internal(n);
 
     for ( std::size_t i = 0; i < n; i++ ) {
         (*this) [ i ] = max( a [ i ], b [ i ] );
@@ -270,7 +272,7 @@ void FloatArray :: beMinOf(const FloatArray &a, const FloatArray &b)
 
 #  endif
 
-    FAST_RESIZE(n);
+    _resize_internal(n);
     for ( std::size_t i = 0; i < n; i++ ) {
         (*this) [ i ] = min( a [ i ], b [ i ] );
     }
@@ -286,7 +288,7 @@ void FloatArray :: beDifferenceOf(const FloatArray &a, const FloatArray &b)
 
 #endif
 #if 0
-    FAST_RESIZE(a.giveSize());
+    _resize_internal(a.giveSize());
     for ( int i = 0; i < this->giveSize(); ++i ) {
         (*this) [ i ] = a [ i ] - b [ i ];
     }
@@ -308,7 +310,7 @@ void FloatArray :: beDifferenceOf(const FloatArray &a, const FloatArray &b, std:
     }
 
 #endif
-    FAST_RESIZE(n);
+    _resize_internal(n);
     for ( std::size_t i = 0; i < n; ++i ) {
         (*this) [ i ] = a [ i ] - b [ i ];
     }
@@ -328,7 +330,7 @@ void FloatArray :: beSubArrayOf(const FloatArray &src, const IntArray &indx)
 #endif
 
     std::size_t n = indx.size();
-    FAST_RESIZE(n);
+    _resize_internal(n);
     for ( std::size_t i = 1; i <= n; i++ ) {
         this->at(i) = src.at( indx.at(i) );
     }
@@ -360,7 +362,7 @@ void FloatArray :: beVectorProductOf(const FloatArray &v1, const FloatArray &v2)
     }
 #  endif
 
-    FAST_RESIZE(3);
+    _resize_internal(3);
 
     this->at(1) = v1.at(2) * v2.at(3) - v1.at(3) * v2.at(2);
     this->at(2) = v1.at(3) * v2.at(1) - v1.at(1) * v2.at(3);
@@ -594,7 +596,7 @@ void FloatArray :: beProductOf(const FloatMatrix &aMatrix, const FloatArray &anA
     std::size_t nColumns = aMatrix.giveNumberOfColumns();
     std::size_t nRows = aMatrix.giveNumberOfRows();
 
-    FAST_RESIZE(nRows);
+    _resize_internal(nRows);
 
 #  ifndef NDEBUG
     if ( aMatrix.giveNumberOfColumns() != anArray.giveSize() ) {
@@ -632,7 +634,7 @@ void FloatArray :: beTProductOf(const FloatMatrix &aMatrix, const FloatArray &an
     }
 
 #  endif
-    FAST_RESIZE(nColumns);
+    _resize_internal(nColumns);
 
 #ifdef __LAPACK_MODULE
     double alpha = 1., beta = 0.;
@@ -919,7 +921,7 @@ double norm_square(const FloatArray &x)
 
 bool isfinite(const FloatArray &x)
 {
-    return x.isFinite();
+    return x.isAllFinite();
 }
 
 bool iszero(const FloatArray &x)
@@ -1079,7 +1081,7 @@ void FloatArray :: beRowOf(const FloatMatrix &mat, std::size_t row)
     }
 #  endif    
     
-    FAST_RESIZE(nColumns);
+    _resize_internal(nColumns);
     for ( std::size_t i = 1; i <= nColumns; i++ ) {
         this->at(i) = mat.at(row,i);
     }

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -69,7 +69,7 @@ extern "C" {
 
 namespace oofem {
 
-bool FloatArray :: isFinite() const
+bool FloatArray :: isAllFinite() const
 {
     for(double val : values) {
         if(!std::isfinite(val)) {
@@ -567,12 +567,6 @@ void FloatArray :: resize(int n)
     //this->values.assign(n, 0.);
 }
 
-
-void FloatArray :: hardResize(int n)
-{
-    this->values.assign(n, 0.);
-    this->values.shrink_to_fit();
-}
 
 
 bool FloatArray :: containsOnlyZeroes() const

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -52,7 +52,7 @@
 #include <iomanip>
 
 namespace oofem{
-void FloatArray::_resize_internal(int newsize){
+void FloatArray::_resize_internal(size_t newsize){
     if ( (newsize) < this->size() ) { \
         this->values.resize((newsize)); \
     } else if ( (newsize) > this->size() ) { \
@@ -741,14 +741,17 @@ void FloatArray :: times(double factor)
     }
 }
 
+void FloatArray :: normalize(){
+    (void) normalize_giveNorm();
+}
 
-double FloatArray :: normalize()
+
+double FloatArray :: normalize_giveNorm()
 {
     double norm = this->computeNorm();
     if ( norm < 1.e-80 ) {
         OOFEM_ERROR("cannot norm receiver, norm is too small");
     }
-
     this->times(1. / norm);
     return norm;
 }

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -71,6 +71,18 @@ extern "C" {
 
 namespace oofem {
 
+
+FloatArray FloatArray::fromConcatenated(std::initializer_list<FloatArray> ini){
+    int len=0; for(const auto& a: ini) len+=a.size();
+    FloatArray ret(len);
+    int ix=0;
+    for(const auto& a: ini){
+        for(size_t i=0; i<a.size(); i++) ret[ix++]=a[i];
+    }
+    return ret;
+}
+
+
 bool FloatArray :: isAllFinite() const
 {
     for(double val : values) {

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -544,13 +544,6 @@ void FloatArray :: checkSizeTowards(const IntArray &loc)
 }
 
 
-void FloatArray :: reserve(int s)
-{
-    this->values.reserve(s);
-    this->values.clear();
-}
-
-
 void FloatArray :: resizeWithValues(std::size_t n, std::size_t allocChunk)
 {
 #ifndef NDEBUG
@@ -599,17 +592,6 @@ void FloatArray :: zero()
     std::fill(this->begin(), this->end(), 0.);
 }
 
-
-void FloatArray :: append(const FloatArray &a)
-{
-    this->values.insert(this->end(), a.begin(), a.end());
-}
-
-
-void FloatArray :: append(double a)
-{
-    this->values.push_back(a);
-}
 
 
 void FloatArray :: beProductOf(const FloatMatrix &aMatrix, const FloatArray &anArray)

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -305,10 +305,9 @@ void FloatArray :: beDifferenceOf(const FloatArray &a, const FloatArray &b)
         (*this) [ i ] = a [ i ] - b [ i ];
     }
 #else
-    this->values.reserve(a.giveSize());
-    this->values.resize(0);
+    this->resize(a.giveSize());
     for ( std::size_t i = 0; i < a.size(); ++i ) {
-        this->values.push_back( a[i] - b[i] );
+        (*this)[i]=a[i] - b[i];
     }
 
 #endif

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -109,6 +109,8 @@ public:
     FloatArray(FloatArray &&src) noexcept : values(std::move(src.values)) { }
     /// Initializer list constructor.
     inline FloatArray(std :: initializer_list< double >list) : values(list) { }
+    static FloatArray fromList(std::initializer_list<double> ini){ return FloatArray(ini); }
+    static FloatArray fromVector(const std::vector<double>& v){ return FloatArray(v.begin(),v.end()); }
     /// Wrapper to direct assignment from iterator pairs
     template< class InputIt >
     FloatArray( InputIt first, InputIt last ) : values(first, last) { }

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -134,7 +134,7 @@ public:
     void push_back(double iVal) { values.push_back(iVal); }
 
     /// Returns true if no element is NAN or infinite
-    bool isFinite() const;
+    bool isAllFinite() const;
 
     /**
      * Coefficient access function. Returns value of coefficient at given
@@ -228,12 +228,6 @@ public:
      * Same effect as resizing to zero, but has a clearer meaning and intent when used.
      */
     void clear() { this->values.clear(); }
-    /**
-     * Resizes the size of the receiver to requested bounds. Memory allocation always happens, more preferably use
-     * resize() function instead. Array is zeroed.
-     * @param s New size.
-     */
-    void hardResize(int s);
     /**
      * Returns nonzero if all coefficients of the receiver are 0, else returns zero.
      */

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -42,6 +42,7 @@
 
 #include <initializer_list>
 #include <vector>
+#include <list>
 #include <iosfwd>
 
 namespace oofem {
@@ -110,8 +111,9 @@ public:
     FloatArray(FloatArray &&src) noexcept : values(std::move(src.values)) { }
     /// Initializer list constructor.
     inline FloatArray(std :: initializer_list< double >list) : values(list) { }
-    static FloatArray fromList(std::initializer_list<double> ini){ return FloatArray(ini); }
-    static FloatArray fromVector(const std::vector<double>& v){ return FloatArray(v.begin(),v.end()); }
+    static FloatArray fromIniList(std::initializer_list<double> ini){ return FloatArray(ini); }
+    static FloatArray fromVector(const std::vector<double>& v){ FloatArray ret; ret.values=v; return ret; }
+    static FloatArray fromList(const std::list<double>& l){ FloatArray ret((int)l.size()); std::copy(l.begin(),l.end(),ret.begin()); return ret; }
     /// Wrapper to direct assignment from iterator pairs
     template< class InputIt >
     FloatArray( InputIt first, InputIt last ) : values(first, last) { }

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -83,7 +83,7 @@ template<std::size_t N> class FloatArrayF;
  */
 class OOFEM_EXPORT FloatArray
 {
-    void _resize_internal(int newsize);
+    void _resize_internal(size_t newsize);
 protected:
     /// Stored values.
     std::vector< double > values;
@@ -441,13 +441,17 @@ public:
      * will have this norm equal to 1.0.
      * @return modified receiver
      */
-    double normalize();
+    double normalize_giveNorm();
+    /**
+     * Normalizes receiver. Euclidean norm is used, after operation receiver
+     * will have this norm equal to 1.0.
+     */
+    void normalize();
     /**
      * Computes the norm (or length) of the vector.
      * @return The Euclidean norm of the vector.
      */
     double computeNorm() const;
-
     /**
      * Computes the square of the norm.
      * @return Squared norm.

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -532,12 +532,6 @@ public:
     /// Assignment of scalar to all components of receiver
     FloatArray &operator = ( const double & );
     //@}
-
-#ifdef _BOOSTPYTHON_BINDINGS
-    void __setitem__(int i, double val) { this->values[i] = val; }
-    double __getitem__(int i) { return this->values[i]; }
-    void beCopyOf(const FloatArray &src) { this->operator = ( src ); }
-#endif
 };
 
 const FloatArray ZeroVector = {0.0,0.0,0.0};

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -114,6 +114,7 @@ public:
     static FloatArray fromIniList(std::initializer_list<double> ini){ return FloatArray(ini); }
     static FloatArray fromVector(const std::vector<double>& v){ FloatArray ret; ret.values=v; return ret; }
     static FloatArray fromList(const std::list<double>& l){ FloatArray ret((int)l.size()); std::copy(l.begin(),l.end(),ret.begin()); return ret; }
+    static FloatArray fromConcatenated(std::initializer_list<FloatArray> ini);
     /// Wrapper to direct assignment from iterator pairs
     template< class InputIt >
     FloatArray( InputIt first, InputIt last ) : values(first, last) { }
@@ -558,6 +559,19 @@ OOFEM_EXPORT bool isfinite(const FloatArray &x);
 OOFEM_EXPORT bool iszero(const FloatArray &x);
 OOFEM_EXPORT double sum(const FloatArray & x);
 OOFEM_EXPORT double product(const FloatArray & x);
+
+
+inline static FloatArray Vec1(const double& a){ return FloatArray::fromIniList({a}); }
+inline static FloatArray Vec2(const double& a, const double& b){ return FloatArray::fromIniList({a,b}); }
+inline static FloatArray Vec3(const double& a, const double& b, const double& c){ return FloatArray::fromIniList({a,b,c}); }
+inline static FloatArray Vec4(const double& a, const double& b, const double& c, const double& d){ return FloatArray::fromIniList({a,b,c,d}); }
+inline static FloatArray Vec5(const double& a, const double& b, const double& c, const double& d, const double& e){ return FloatArray::fromIniList({a,b,c,d,e}); }
+inline static FloatArray Vec6(const double& a, const double& b, const double& c, const double& d, const double& e, const double& f){ return FloatArray::fromIniList({a,b,c,d,e,f}); }
+inline static FloatArray Vec7(const double& a, const double& b, const double& c, const double& d, const double& e, const double& f, const double& g){ return FloatArray::fromIniList({a,b,c,d,e,f,g}); }
+inline static FloatArray Vec8(const double& a, const double& b, const double& c, const double& d, const double& e, const double& f, const double& g, const double& h){ return FloatArray::fromIniList({a,b,c,d,e,f,g,h}); }
+inline static FloatArray Vec9(const double& a, const double& b, const double& c, const double& d, const double& e, const double& f, const double& g, const double& h, const double& i){ return FloatArray::fromIniList({a,b,c,d,e,f,g,h,i}); }
+inline static FloatArray VecX(std::initializer_list<double> ini){ return FloatArray::fromIniList(ini); }
+
 //@}
 } // end namespace oofem
 #endif // floatarray_h

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -83,6 +83,7 @@ template<std::size_t N> class FloatArrayF;
  */
 class OOFEM_EXPORT FloatArray
 {
+    void _resize_internal(int newsize);
 protected:
     /// Stored values.
     std::vector< double > values;

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -209,11 +209,6 @@ public:
      */
     void checkSizeTowards(const IntArray &loc);
     /**
-     * Allocates enough size to fit s, and clears the array.
-     * @param s New reserved size.
-     */
-    void reserve(int s);
-    /**
      * Checks size of receiver towards requested bounds.
      * If dimension mismatch, size is adjusted accordingly.
      * Old values are copied over and new space is zeroed.
@@ -274,16 +269,6 @@ public:
     virtual void pY() const;
     /// Zeroes all coefficients of receiver.
     void zero();
-    /**
-     * Appends array to reciever.
-     * @param a Values to be appended.
-     */
-    void append(const FloatArray &a);
-    /**
-     * Appends value to reciever.
-     * @param a Value to be appended.
-     */
-    void append(double a);
     /**
      * Receiver becomes the result of the product of aMatrix and anArray.
      * Adjusts the size of receiver if necessary.

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -134,9 +134,6 @@ public:
     template< std::size_t N >
     inline FloatArray &operator = (const FloatArrayF<N> &src) { values.assign(src.begin(), src.end()); return *this; }
 
-    /// Add one element
-    void push_back(double iVal) { values.push_back(iVal); }
-
     /// Returns true if no element is NAN or infinite
     bool isAllFinite() const;
 

--- a/src/oofemlib/floatmatrix.C
+++ b/src/oofemlib/floatmatrix.C
@@ -47,7 +47,9 @@
 #include <fstream>
 #include <iomanip>
 #include <numeric>
-#define RESIZE(nr, nc) \
+
+namespace oofem{
+void FloatMatrix::_resize_internal(int nr, int nc)
     { \
         this->nRows = nr; this->nColumns = nc; \
         std::size_t nsize = this->nRows * this->nColumns; \
@@ -57,6 +59,8 @@
             this->values.assign(nsize, 0.); \
         } \
     }
+};
+
 
 #ifdef _BOOSTPYTHON_BINDINGS
  #include <boost/python.hpp>
@@ -125,7 +129,7 @@ FloatMatrix :: FloatMatrix(const FloatArray &vector, bool transpose)
 
 FloatMatrix :: FloatMatrix(std :: initializer_list< std :: initializer_list< double > >mat)
 {
-    RESIZE( mat.size(), mat.begin()->size() )
+    _resize_internal( mat.size(), mat.begin()->size() );
     auto p = this->values.begin();
     for ( auto col : mat ) {
 #if DEBUG
@@ -143,7 +147,7 @@ FloatMatrix :: FloatMatrix(std :: initializer_list< std :: initializer_list< dou
 
 FloatMatrix &FloatMatrix :: operator = ( std :: initializer_list< std :: initializer_list< double > >mat )
 {
-    RESIZE( ( int ) mat.begin()->size(), ( int ) mat.size() );
+    _resize_internal( ( int ) mat.begin()->size(), ( int ) mat.size() );
     auto p = this->values.begin();
     for ( auto col : mat ) {
 #if DEBUG
@@ -163,7 +167,7 @@ FloatMatrix &FloatMatrix :: operator = ( std :: initializer_list< std :: initial
 
 FloatMatrix &FloatMatrix :: operator = ( std :: initializer_list< FloatArray >mat )
 {
-    RESIZE( mat.begin()->giveSize(), ( int ) mat.size() );
+    _resize_internal( mat.begin()->giveSize(), ( int ) mat.size() );
     auto p = this->values.begin();
     for ( auto col : mat ) {
 #if DEBUG
@@ -315,7 +319,7 @@ void FloatMatrix :: beTranspositionOf(const FloatMatrix &src)
 {
     // receiver becomes a transposition of src
     int nrows = src.giveNumberOfColumns(), ncols = src.giveNumberOfRows();
-    RESIZE(nrows, ncols);
+    _resize_internal(nrows, ncols);
 
     for ( int i = 1; i <= nrows; i++ ) {
         for ( int j = 1; j <= ncols; j++ ) {
@@ -333,7 +337,7 @@ void FloatMatrix :: beProductOf(const FloatMatrix &aMatrix, const FloatMatrix &b
         OOFEM_ERROR("error in product A*B : dimensions do not match, A(*,%d), B(%d,*)", aMatrix.nColumns, bMatrix.nRows);
     }
 #  endif
-    RESIZE(aMatrix.nRows, bMatrix.nColumns);
+    _resize_internal(aMatrix.nRows, bMatrix.nColumns);
 #  ifdef __LAPACK_MODULE
     double alpha = 1., beta = 0.;
     dgemm_("n", "n", & this->nRows, & this->nColumns, & aMatrix.nColumns,
@@ -363,7 +367,7 @@ void FloatMatrix :: beTProductOf(const FloatMatrix &aMatrix, const FloatMatrix &
         OOFEM_ERROR("error in product A*B : dimensions do not match");
     }
 #  endif
-    RESIZE(aMatrix.nColumns, bMatrix.nColumns);
+    _resize_internal(aMatrix.nColumns, bMatrix.nColumns);
 #  ifdef __LAPACK_MODULE
     double alpha = 1., beta = 0.;
     dgemm_("t", "n", & this->nRows, & this->nColumns, & aMatrix.nRows,
@@ -393,7 +397,7 @@ void FloatMatrix :: beProductTOf(const FloatMatrix &aMatrix, const FloatMatrix &
         OOFEM_ERROR("error in product A*B : dimensions do not match");
     }
 #  endif
-    RESIZE(aMatrix.nRows, bMatrix.nRows);
+    _resize_internal(aMatrix.nRows, bMatrix.nRows);
 #  ifdef __LAPACK_MODULE
     double alpha = 1., beta = 0.;
     dgemm_("n", "t", & this->nRows, & this->nColumns, & aMatrix.nColumns,
@@ -485,7 +489,7 @@ void FloatMatrix :: beDyadicProductOf(const FloatArray &vec1, const FloatArray &
 {
     int n1 = vec1.giveSize();
     int n2 = vec2.giveSize();
-    RESIZE(n1, n2);
+    _resize_internal(n1, n2);
     for ( int j = 1; j <= n2; j++ ) {
         for ( int i = 1; i <= n1; i++ ) {
             this->at(i, j) = vec1.at(i) * vec2.at(j);
@@ -834,7 +838,7 @@ bool FloatMatrix :: beInverseOf(const FloatMatrix &src)
     }
 #  endif
 
-    RESIZE(src.nRows, src.nColumns);
+    _resize_internal(src.nRows, src.nColumns);
 
     if ( nRows == 1 ) {
         if (fabs(src.at(1,1)) > 1.e-30) {

--- a/src/oofemlib/floatmatrix.C
+++ b/src/oofemlib/floatmatrix.C
@@ -62,10 +62,6 @@ void FloatMatrix::_resize_internal(int nr, int nc)
 };
 
 
-#ifdef _BOOSTPYTHON_BINDINGS
- #include <boost/python.hpp>
- #include <boost/python/extract.hpp>
-#endif
 
 // Some forward declarations for LAPACK. Remember to append the underscore to the function name.
 #ifdef __LAPACK_MODULE

--- a/src/oofemlib/floatmatrix.C
+++ b/src/oofemlib/floatmatrix.C
@@ -201,7 +201,7 @@ void FloatMatrix :: checkBounds(std::size_t i, std::size_t j) const
     }
 }
 
-bool FloatMatrix :: isFinite() const
+bool FloatMatrix :: isAllFinite() const
 {
     for (double val : values) {
         if ( !std::isfinite(val) ) {
@@ -1385,17 +1385,6 @@ void FloatMatrix :: resizeWithData(std::size_t rows, std::size_t columns)
     }
 }
 
-
-void FloatMatrix :: hardResize(int rows, int columns)
-//
-// resizes receiver, all data will be lost
-//
-{
-    this->nRows = rows;
-    this->nColumns = columns;
-    values.assign(rows * columns, 0.);
-    this->values.shrink_to_fit();
-}
 
 
 double FloatMatrix :: giveDeterminant() const

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -605,14 +605,6 @@ public:
 
     friend std :: ostream &operator<<(std :: ostream &out, const FloatMatrix &r);
 
-
-#ifdef _BOOSTPYTHON_BINDINGS
-    void __setitem__(boost :: python :: api :: object t, double val);
-    double __getitem__(boost :: python :: api :: object t);
-    void beCopyOf(const FloatMatrix &src) { this->operator=(src); }
-#endif
-
-
 }; // class FloatMatrix
 
 //@name operators

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -184,7 +184,7 @@ public:
     inline bool isNotEmpty() const { return nRows > 0 && nColumns > 0; }
 
     /// Returns true if no element is NAN or infinite
-    bool isFinite() const;
+    bool isAllFinite() const;
 
     /**
      * Coefficient access function. Returns value of coefficient at given
@@ -544,13 +544,7 @@ public:
      * Note: New coefficients are initialized to zero, old are kept.
      */
     void resizeWithData(std::size_t, std::size_t);
-    /**
-     * Resizing that enforces reallocation of memory.
-     * Data is zeroed.
-     * @param r Number of rows.
-     * @param c Number of columns.
-     */
-    void hardResize(int r, int c);
+
     /// Sets size of receiver to be an empty matrix. It will have zero rows and zero columns size.
     void clear() {
         this->nRows = 0;

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -45,16 +45,6 @@
 #include <algorithm>
 #include <string>
 
-#ifdef _BOOSTPYTHON_BINDINGS
-namespace boost {
-namespace python {
-namespace api {
-class object;
-};
-};
-};
-#endif
-
 namespace oofem {
 class FloatArray;
 template<std::size_t N> class FloatArrayF;
@@ -90,6 +80,7 @@ class DataStream;
  */
 class OOFEM_EXPORT FloatMatrix
 {
+    void _resize_internal(int nr, int nc);
 protected:
     /// Number of rows.
     std::size_t nRows;

--- a/src/oofemlib/geometry.C
+++ b/src/oofemlib/geometry.C
@@ -877,7 +877,7 @@ void PolygonLine :: computeNormalSignDist(double &oDist, const FloatArray &iPoin
             double l2 = t.computeSquaredNorm();
 
             if ( l2 > 0.0 ) {
-                double l = t.normalize();
+                double l = t.normalize_giveNorm();
                 double s = dot(u, t);
 
                 if ( s > l ) {
@@ -903,7 +903,7 @@ void PolygonLine :: computeNormalSignDist(double &oDist, const FloatArray &iPoin
             double l2 = t.computeSquaredNorm();
 
             if ( l2 > 0.0 ) {
-                double l = t.normalize();
+                double l = t.normalize_giveNorm();
                 double s = dot(u, t);
 
                 if ( s < 0.0 ) {

--- a/src/oofemlib/intarray.C
+++ b/src/oofemlib/intarray.C
@@ -204,7 +204,7 @@ void IntArray :: printYourself(const std::string name) const
     printf("\n");
 }
 
-bool IntArray :: isFinite() const
+bool IntArray :: isAllFinite() const
 {
     for ( int val : values ) {
         if( !std::isfinite((double)val) ) {

--- a/src/oofemlib/intarray.h
+++ b/src/oofemlib/intarray.h
@@ -336,7 +336,7 @@ public:
     void printYourselfToFile(const std::string filename, const bool showDimensions=true) const;
 
     /// Returns true if no element is NAN or infinite
-    bool isFinite() const;
+    bool isAllFinite() const;
 
     /**
      * Breaks encapsulation. Avoid using this unless absolutely necessary.

--- a/src/oofemlib/intarray.h
+++ b/src/oofemlib/intarray.h
@@ -361,6 +361,8 @@ public:
 
 
     friend std :: ostream &operator << ( std :: ostream & out, const IntArray & x );
+
+    std::vector<int> minusOne() const { std::vector<int> ret(values.size()); for(size_t i=0; i<values.size(); i++) ret[i]=values[i]-1; return ret; }
 };
 
 

--- a/src/oofemlib/intarray.h
+++ b/src/oofemlib/intarray.h
@@ -361,12 +361,6 @@ public:
 
 
     friend std :: ostream &operator << ( std :: ostream & out, const IntArray & x );
-
-#ifdef _BOOSTPYTHON_BINDINGS
-    void __setitem__(int i, int val) { this->at(i + 1) = val; }
-    int __getitem__(int i) { return this->at(i + 1); }
-    void beCopyOf(const IntArray &src) { this->operator = ( src ); }
-#endif
 };
 
 

--- a/src/oofemlib/intarrayf.h
+++ b/src/oofemlib/intarrayf.h
@@ -324,7 +324,7 @@ public:
     void printYourselfToFile(const std::string filename, const bool showDimensions=true) const;
 
     /// Returns true if no element is NAN or infinite
-    bool isFinite() const;
+    bool isAllFinite() const;
 
     /**
      * Breaks encapsulation. Avoid using this unless absolutely necessary.

--- a/src/oofemlib/intarrayf.h
+++ b/src/oofemlib/intarrayf.h
@@ -349,12 +349,6 @@ public:
 
 
     friend std :: ostream &operator << ( std :: ostream & out, const IntArray & x );
-
-#ifdef _BOOSTPYTHON_BINDINGS
-    void __setitem__(int i, int val) { this->at(i + 1) = val; }
-    int __getitem__(int i) { return this->at(i + 1); }
-    void beCopyOf(const IntArray &src) { this->operator = ( src ); }
-#endif
 };
 
 

--- a/src/oofemlib/prescribedgradientbcweak.C
+++ b/src/oofemlib/prescribedgradientbcweak.C
@@ -298,14 +298,14 @@ void PrescribedGradientBCWeak :: assembleVector(FloatArray &answer, TimeStep *tS
             IntArray dispLockRows;
             mpDisplacementLock->giveLocationArray(giveDispLockDofIDs(), dispLockRows, s);
 
-            FloatArray fe_dispLock;
 
             int lockNodePlaceInArray = domain->giveDofManPlaceInArray(mLockNodeInd);
             FloatArray nodeUnknowns;
             domain->giveDofManager(lockNodePlaceInArray)->giveUnknownVector(nodeUnknowns,this->giveRegularDispDofIDs(), mode, tStep);
 
+            FloatArray fe_dispLock(domain->giveNumberOfSpatialDimensions());
             for ( int i = 0; i < domain->giveNumberOfSpatialDimensions(); i++ ) {
-                fe_dispLock.push_back(nodeUnknowns [ i ]);
+                fe_dispLock[i] = nodeUnknowns [ i ];
             }
 
             fe_dispLock.times(mDispLockScaling);
@@ -379,8 +379,8 @@ void PrescribedGradientBCWeak :: computeIntForceGPContrib(FloatArray &oContrib_d
     Element *dispEl = localizer->giveElementClosestToPoint(dispElLocCoord, closestPoint, iBndCoord );
 
     // Compute vector of displacement unknowns
-    FloatArray dispUnknowns;
     int numDMan = dispEl->giveNumberOfDofManagers();
+    std::vector<double> dispUnknowns_;
     for ( int i = 1; i <= numDMan; i++ ) {
         FloatArray nodeUnknowns;
         DofManager *dMan = dispEl->giveDofManager(i);
@@ -392,7 +392,7 @@ void PrescribedGradientBCWeak :: computeIntForceGPContrib(FloatArray &oContrib_d
         }
 
         dMan->giveUnknownVector(nodeUnknowns, dispIDs,mode, tStep);
-        dispUnknowns.append(nodeUnknowns);
+        dispUnknowns_.insert(dispUnknowns_.end(),nodeUnknowns.begin(),nodeUnknowns.end());
 
     }
 
@@ -402,6 +402,7 @@ void PrescribedGradientBCWeak :: computeIntForceGPContrib(FloatArray &oContrib_d
     oContrib_disp.beTProductOf(contrib, tracUnknowns);
     oContrib_disp.negated();
 
+    FloatArray dispUnknowns(dispUnknowns_.begin(),dispUnknowns_.end());
     oContrib_trac.beProductOf(contrib, dispUnknowns);
     oContrib_trac.negated();
 }

--- a/src/oofemlib/prescribedgradientbcweak.C
+++ b/src/oofemlib/prescribedgradientbcweak.C
@@ -402,7 +402,7 @@ void PrescribedGradientBCWeak :: computeIntForceGPContrib(FloatArray &oContrib_d
     oContrib_disp.beTProductOf(contrib, tracUnknowns);
     oContrib_disp.negated();
 
-    FloatArray dispUnknowns(dispUnknowns_.begin(),dispUnknowns_.end());
+    FloatArray dispUnknowns=FloatArray::fromVector(dispUnknowns_);
     oContrib_trac.beProductOf(contrib, dispUnknowns);
     oContrib_trac.negated();
 }

--- a/src/oofemlib/xfem/geometrybasedei.C
+++ b/src/oofemlib/xfem/geometrybasedei.C
@@ -181,7 +181,7 @@ void GeometryBasedEI :: updateDofIdPool()
 
 void GeometryBasedEI :: appendInputRecords(DynamicDataReader &oDR)
 {
-    auto eiRec = std::unique_ptr<DynamicInputRecord>();
+    auto eiRec = std::make_unique<DynamicInputRecord>();
     FEMComponent :: giveInputRecord(* eiRec);
 
     eiRec->setField(mEnrFrontIndex,                     _IFT_EnrichmentItem_front);

--- a/src/sm/Elements/3D/lspace.C
+++ b/src/sm/Elements/3D/lspace.C
@@ -716,7 +716,7 @@ LSpace :: computeLoadLSToLRotationMatrix(FloatMatrix &answer, int isurf, GaussPo
         h1.normalize();
         h2 = domain->giveNode( snodes.at(j) )->giveCoordinates();
         h2.subtract(gc);
-        h2.normalize();	
+        h2.normalize();
         n.beVectorProductOf(h1, h2);
 
         nn.add(n);

--- a/src/sm/Elements/Bars/truss3dnl2.C
+++ b/src/sm/Elements/Bars/truss3dnl2.C
@@ -60,8 +60,11 @@ void
 Truss3dnl2 :: initializeFrom(InputRecord &ir)
 {
   Truss3d :: initializeFrom(ir);
-  X = this-> giveCellGeometryWrapper()->giveVertexCoordinates( 1 );
-  X.append(this-> giveCellGeometryWrapper()->giveVertexCoordinates( 2 ));
+  FloatArray vc1 = this-> giveCellGeometryWrapper()->giveVertexCoordinates( 1 );
+  FloatArray vc2 = this-> giveCellGeometryWrapper()->giveVertexCoordinates( 2 );
+  X.resize(vc1.size()+vc2.size());
+  X.copySubVector(vc1,1);
+  X.copySubVector(vc2,vc1.size()+1);
   L = this->computeLength();
 }
 

--- a/src/sm/Elements/Bars/truss3dnl2.C
+++ b/src/sm/Elements/Bars/truss3dnl2.C
@@ -62,9 +62,7 @@ Truss3dnl2 :: initializeFrom(InputRecord &ir)
   Truss3d :: initializeFrom(ir);
   FloatArray vc1 = this-> giveCellGeometryWrapper()->giveVertexCoordinates( 1 );
   FloatArray vc2 = this-> giveCellGeometryWrapper()->giveVertexCoordinates( 2 );
-  X.resize(vc1.size()+vc2.size());
-  X.copySubVector(vc1,1);
-  X.copySubVector(vc2,vc1.size()+1);
+  X=FloatArray::fromConcatenated({vc1,vc2});
   L = this->computeLength();
 }
 

--- a/src/sm/Quasicontinuum/quasicontinuum.C
+++ b/src/sm/Quasicontinuum/quasicontinuum.C
@@ -807,9 +807,10 @@ Quasicontinuum :: stiffnessAssignment(std :: vector< FloatMatrix > &individualSt
         return true;
     } else {   // ends are located in different elements -> all intersected el needs to be found
         IntArray intersected; // to store numbers of intersected elem
-        FloatArray lengths; // to store lengths ofintersections
+        std::vector<double> lengths_; // to store lengths ofintersections
 
-        computeIntersectionsOfLinkWithInterpElements(intersected, lengths, d, e, qn1, qn2);
+        computeIntersectionsOfLinkWithInterpElements(intersected, lengths_, d, e, qn1, qn2);
+        FloatArray lengths(lengths_.begin(),lengths_.end());
 
         // check: is there any intersectted elements
         int noIntersected = lengths.giveSize();
@@ -844,7 +845,7 @@ Quasicontinuum :: stiffnessAssignment(std :: vector< FloatMatrix > &individualSt
 
 
 void
-Quasicontinuum :: computeIntersectionsOfLinkWithInterpElements(IntArray &intersected, FloatArray &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2)
+Quasicontinuum :: computeIntersectionsOfLinkWithInterpElements(IntArray &intersected, std::vector<double> &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2)
 {
     int dim = d->giveNumberOfSpatialDimensions();
     if ( dim == 2 ) {
@@ -858,7 +859,7 @@ Quasicontinuum :: computeIntersectionsOfLinkWithInterpElements(IntArray &interse
 
 
 bool
-Quasicontinuum :: computeIntersectionsOfLinkWith2DTringleElements(IntArray &intersected, FloatArray &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2)
+Quasicontinuum :: computeIntersectionsOfLinkWith2DTringleElements(IntArray &intersected, std::vector<double> &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2)
 {
     intersected.clear();
     lengths.clear();
@@ -1043,7 +1044,7 @@ Quasicontinuum :: computeIntersectionsOfLinkWith2DTringleElements(IntArray &inte
 
 
         // check: all length of link is assembles
-        sumLength = lengths.sum();
+        sumLength = std::accumulate(lengths.begin(), lengths.end(), 0.);
         if ( ( fabs(sumLength / TotalLength - 1) ) <= ( 0.0001 ) ) {
             return true;
         }
@@ -1059,7 +1060,7 @@ Quasicontinuum :: computeIntersectionsOfLinkWith2DTringleElements(IntArray &inte
 
 
 bool
-Quasicontinuum :: computeIntersectionsOfLinkWith3DTetrahedraElements(IntArray &intersected, FloatArray &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2)
+Quasicontinuum :: computeIntersectionsOfLinkWith3DTetrahedraElements(IntArray &intersected, std::vector<double> &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2)
 {
     intersected.clear();
     lengths.clear();
@@ -1247,7 +1248,7 @@ Quasicontinuum :: computeIntersectionsOfLinkWith3DTetrahedraElements(IntArray &i
 
 
         // check: all length of link is assembles
-        sumLength = lengths.sum();
+        sumLength = std::accumulate(lengths.begin(), lengths.end(), 0.);
         if ( ( fabs(sumLength / TotalLength - 1) ) <= ( 0.0001 ) ) {
             return true;
         }

--- a/src/sm/Quasicontinuum/quasicontinuum.C
+++ b/src/sm/Quasicontinuum/quasicontinuum.C
@@ -810,7 +810,7 @@ Quasicontinuum :: stiffnessAssignment(std :: vector< FloatMatrix > &individualSt
         std::vector<double> lengths_; // to store lengths ofintersections
 
         computeIntersectionsOfLinkWithInterpElements(intersected, lengths_, d, e, qn1, qn2);
-        FloatArray lengths(lengths_.begin(),lengths_.end());
+        FloatArray lengths=FloatArray::fromVector(lengths_);
 
         // check: is there any intersectted elements
         int noIntersected = lengths.giveSize();

--- a/src/sm/Quasicontinuum/quasicontinuum.h
+++ b/src/sm/Quasicontinuum/quasicontinuum.h
@@ -74,9 +74,9 @@ public:
     void computeStiffnessTensorOf1Link(FloatMatrix &D1, double &S0, Element *e, Domain *d);
     bool stiffnessAssignment( std::vector<FloatMatrix> &individualStiffnessTensors, FloatArray &individialS0, Domain *d, Element *e, qcNode *qn1, qcNode *qn2 );
 
-    void computeIntersectionsOfLinkWithInterpElements( IntArray &intersected, FloatArray &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2);
-    bool computeIntersectionsOfLinkWith2DTringleElements( IntArray &intersected, FloatArray &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2);
-    bool computeIntersectionsOfLinkWith3DTetrahedraElements( IntArray &intersected, FloatArray &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2);
+    void computeIntersectionsOfLinkWithInterpElements( IntArray &intersected, std::vector<double> & lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2);
+    bool computeIntersectionsOfLinkWith2DTringleElements( IntArray &intersected, std::vector<double> &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2);
+    bool computeIntersectionsOfLinkWith3DTetrahedraElements( IntArray &intersected, std::vector<double> &lengths, Domain *d, Element *e, qcNode *qn1, qcNode *qn2);
 
     void initializeConnectivityTableForInterpolationElements( Domain *d );
 

--- a/src/sm/export/gnuplotexportmodule.C
+++ b/src/sm/export/gnuplotexportmodule.C
@@ -787,28 +787,31 @@ void GnuplotExportModule::outputBoundaryCondition(PrescribedGradientBCWeak &iBC,
 
             // Add the start and end nodes of the segment
             DofManager *startNode = e->giveDofManager( bNodes[0] );
-            FloatArray xS = startNode->giveCoordinates();
+            int dim=startNode->giveCoordinates().size();
+            FloatArray xS(dim+2);
+            xS.copySubVector(startNode->giveCoordinates(),1);
 
             Dof *dSu = startNode->giveDofWithID(D_u);
             double dU = dSu->giveUnknown(VM_Total, tStep);
-            xS.push_back(dU);
+            xS.at(dim+1)=dU;
 
             Dof *dSv = startNode->giveDofWithID(D_v);
             double dV = dSv->giveUnknown(VM_Total, tStep);
-            xS.push_back(dV);
+            xS.at(dim+2)=dV;
 
             bndSegNodes.push_back(xS);
 
             DofManager *endNode = e->giveDofManager( bNodes[1] );
-            FloatArray xE = endNode->giveCoordinates();
+            FloatArray xE(dim+2);
+            xE.copySubVector(endNode->giveCoordinates(),1);
 
             Dof *dEu = endNode->giveDofWithID(D_u);
             dU = dEu->giveUnknown(VM_Total, tStep);
-            xE.push_back(dU);
+            xE.at(dim+1)=dU;
 
             Dof *dEv = endNode->giveDofWithID(D_v);
             dV = dEv->giveUnknown(VM_Total, tStep);
-            xE.push_back(dV);
+            xE.at(dim+2)=dV;
 
             bndSegNodes.push_back(xE);
 

--- a/src/sm/export/gnuplotexportmodule.C
+++ b/src/sm/export/gnuplotexportmodule.C
@@ -787,33 +787,24 @@ void GnuplotExportModule::outputBoundaryCondition(PrescribedGradientBCWeak &iBC,
 
             // Add the start and end nodes of the segment
             DofManager *startNode = e->giveDofManager( bNodes[0] );
-            int dim=startNode->giveCoordinates().size();
-            FloatArray xS(dim+2);
-            xS.copySubVector(startNode->giveCoordinates(),1);
 
             Dof *dSu = startNode->giveDofWithID(D_u);
             double dU = dSu->giveUnknown(VM_Total, tStep);
-            xS.at(dim+1)=dU;
 
             Dof *dSv = startNode->giveDofWithID(D_v);
             double dV = dSv->giveUnknown(VM_Total, tStep);
-            xS.at(dim+2)=dV;
 
-            bndSegNodes.push_back(xS);
+            bndSegNodes.push_back(FloatArray::fromConcatenated({startNode->giveCoordinates(),Vec2(dU,dV)}));
 
             DofManager *endNode = e->giveDofManager( bNodes[1] );
-            FloatArray xE(dim+2);
-            xE.copySubVector(endNode->giveCoordinates(),1);
 
             Dof *dEu = endNode->giveDofWithID(D_u);
             dU = dEu->giveUnknown(VM_Total, tStep);
-            xE.at(dim+1)=dU;
 
             Dof *dEv = endNode->giveDofWithID(D_v);
             dV = dEv->giveUnknown(VM_Total, tStep);
-            xE.at(dim+2)=dV;
 
-            bndSegNodes.push_back(xE);
+            bndSegNodes.push_back(FloatArray::fromConcatenated({endNode->giveCoordinates(),Vec2(dU,dV)}));
 
             bndNodes.push_back(bndSegNodes);
         }

--- a/src/sm/mappers/primvarmapper.C
+++ b/src/sm/mappers/primvarmapper.C
@@ -186,7 +186,7 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
 
 
                     // Fetch nodal displacements for the old element
-                    FloatArray nodeDispOld;
+                    std::vector<double> nodeDispOld_;
                     dofsPassed = 1;
                     IntArray elDofsGlobOld;
                     elOld->giveLocationArray( elDofsGlobOld, num );
@@ -212,11 +212,11 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
                                         OOFEM_ERROR("dofUnknowns.giveSize() < 1")
                                     }
 #endif
-                                    nodeDispOld.push_back(dofUnknowns.at(1));
+                                    nodeDispOld_.push_back(dofUnknowns.at(1));
                                 }
                                 else {
                                     // TODO: Why does this case occur?
-                                    nodeDispOld.push_back(0.0);
+                                    nodeDispOld_.push_back(0.0);
                                 }
                             } else {
                                 if ( dof->hasBc(& iTStep) ) {
@@ -226,11 +226,11 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
                                         OOFEM_ERROR("!std::isfinite(dof->giveBcValue(iMode, & iTStep))")
                                     }
 #endif
-                                    nodeDispOld.push_back( dof->giveBcValue(iMode, & iTStep) );
+                                    nodeDispOld_.push_back( dof->giveBcValue(iMode, & iTStep) );
                                 }
                                 else {
 //                                    printf("Unhandled case in LSPrimaryVariableMapper :: mapPrimaryVariables().\n");
-                                    nodeDispOld.push_back( 0.0 );
+                                    nodeDispOld_.push_back( 0.0 );
                                 }
                             }
 
@@ -241,6 +241,7 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
 
 
                     FloatArray oldDisp;
+                    FloatArray nodeDispOld(nodeDispOld_.begin(),nodeDispOld_.end());
                     oldDisp.beProductOf(NOld, nodeDispOld);
 
                     FloatArray temp, duu;

--- a/src/sm/mappers/primvarmapper.C
+++ b/src/sm/mappers/primvarmapper.C
@@ -241,7 +241,7 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
 
 
                     FloatArray oldDisp;
-                    FloatArray nodeDispOld(nodeDispOld_.begin(),nodeDispOld_.end());
+                    FloatArray nodeDispOld=FloatArray::fromVector(nodeDispOld_);
                     oldDisp.beProductOf(NOld, nodeDispOld);
 
                     FloatArray temp, duu;

--- a/src/sm/mappers/primvarmapper.C
+++ b/src/sm/mappers/primvarmapper.C
@@ -204,8 +204,8 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
                                     dof->giveUnknowns(dofUnknowns, iMode, &iTStep);
 
 #ifdef DEBUG
-                                    if(!dofUnknowns.isFinite()) {
-                                        OOFEM_ERROR("!dofUnknowns.isFinite()")
+                                    if(!dofUnknowns.isAllFinite()) {
+                                        OOFEM_ERROR("!dofUnknowns.isAllFinite()")
                                     }
 
                                     if(dofUnknowns.giveSize() < 1) {
@@ -247,12 +247,12 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
                     FloatArray temp, duu;
 
 #ifdef DEBUG
-                    if(!oldDisp.isFinite()) {
-                        OOFEM_ERROR("!oldDisp.isFinite()")
+                    if(!oldDisp.isAllFinite()) {
+                        OOFEM_ERROR("!oldDisp.isAllFinite()")
                     }
 
-                    if(!newDisp.isFinite()) {
-                        OOFEM_ERROR("!newDisp.isFinite()")
+                    if(!newDisp.isAllFinite()) {
+                        OOFEM_ERROR("!newDisp.isAllFinite()")
                     }
 #endif
 
@@ -273,8 +273,8 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
             elNew->computeConsistentMassMatrix(me, & iTStep, mass, & density);
 
 #ifdef DEBUG
-            if(!me.isFinite()) {
-                OOFEM_ERROR("!me.isFinite()")
+            if(!me.isAllFinite()) {
+                OOFEM_ERROR("!me.isAllFinite()")
             }
 #endif
 
@@ -320,8 +320,8 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
         }
 
 #ifdef DEBUG
-        if(!res.isFinite()) {
-            OOFEM_ERROR("!res.isFinite()")
+        if(!res.isAllFinite()) {
+            OOFEM_ERROR("!res.isAllFinite()")
         }
 #endif
 
@@ -334,8 +334,8 @@ void LSPrimaryVariableMapper :: mapPrimaryVariables(FloatArray &oU, Domain &iOld
         solver->solve(*K, res, du);
 
 #ifdef DEBUG
-        if(!du.isFinite()) {
-            OOFEM_ERROR("!du.isFinite()")
+        if(!du.isAllFinite()) {
+            OOFEM_ERROR("!du.isAllFinite()")
         }
 #endif
 

--- a/src/sm/strainvector.C
+++ b/src/sm/strainvector.C
@@ -119,7 +119,7 @@ StrainVector :: computePrincipalValues(FloatArray &answer) const
 
         ast = this->at(1) + this->at(2);
         dst = this->at(1) - this->at(2);
-        D = sqrt( dst * dst + this->at(3) * this->at(3) );
+        D = std::sqrt( dst * dst + this->at(3) * this->at(3) );
         answer.at(1) = 0.5 * ( ast + D );
         answer.at(2) = 0.5 * ( ast - D );
     } else {
@@ -294,8 +294,11 @@ StrainVector :: computePrincipalValDir(FloatArray &answer, FloatMatrix &dir) con
 void
 StrainVector :: printYourself() const
 {
+    #ifdef _USE_EIGEN
+        const StrainVector& values(*this);
+    #endif
     printf("StrainVector (MaterialMode %d)\n", mode);
-    for ( double x : this->values ) {
+    for ( double x : values ) {
         printf("%10.3e  ", x);
     }
 
@@ -309,6 +312,9 @@ StrainVector :: computeVolumeChange() const
     //
     // This function computes the change of volume. This is different from the volumetric strain.
     //
+    #ifdef _USE_EIGEN
+        const StrainVector& values(*this);
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         // 1d problem
@@ -328,20 +334,23 @@ StrainVector :: computeStrainNorm() const
     //
     // This function computes the tensorial Norm of the strain in engineering notation
     //
+    #ifdef _USE_EIGEN
+        const StrainVector& values(*this);
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         // 1d problem
-        return sqrt(values [ 0 ] * values [ 0 ]);
+        return std::sqrt(values [ 0 ] * values [ 0 ]);
     } else if ( myMode == _PlaneStress ) {
         // 2d problem: plane stress
-        return sqrt( .5 * ( 2. * values [ 0 ] * values [ 0 ] + 2 * values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] ) );
+        return std::sqrt( .5 * ( 2. * values [ 0 ] * values [ 0 ] + 2 * values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] ) );
     } else if ( myMode == _PlaneStrain ) {
         //  plane strain or axisymmetry
-        return sqrt( .5 * ( 2. * values [ 0 ] * values [ 0 ] + 2. * values [ 1 ] * values [ 1 ] + 2. * values [ 2 ] * values [ 2 ] +
+        return std::sqrt( .5 * ( 2. * values [ 0 ] * values [ 0 ] + 2. * values [ 1 ] * values [ 1 ] + 2. * values [ 2 ] * values [ 2 ] +
                             values [ 3 ] * values [ 3 ] ) );
     } else {
         // 3d problem
-        return sqrt( .5 * ( 2. * values [ 0 ] * values [ 0 ] + 2. * values [ 1 ] * values [ 1 ] + 2. * values [ 2 ] * values [ 2 ] +
+        return std::sqrt( .5 * ( 2. * values [ 0 ] * values [ 0 ] + 2. * values [ 1 ] * values [ 1 ] + 2. * values [ 2 ] * values [ 2 ] +
                             values [ 3 ] * values [ 3 ] + values [ 4 ] * values [ 4 ] + values [ 5 ] * values [ 5 ] ) );
     }
 }
@@ -353,6 +362,9 @@ StrainVector :: applyElasticStiffness(StressVector &stress, const double EModulu
     // This function applies the elastic stiffness to the total strain vector
     //
 
+    #ifdef _USE_EIGEN
+        const StrainVector& values(*this);
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         stress(0) = EModulus * values [ 0 ];
@@ -406,6 +418,9 @@ StrainVector :: applyDeviatoricElasticStiffness(StressVector &stress,
     // This function applies the elastic stiffness to the deviatoric strain vector
     //
 
+    #ifdef _USE_EIGEN
+        const StrainVector& values(*this);
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         OOFEM_ERROR("No Split for 1D");

--- a/src/sm/stressstrainbasevector.C
+++ b/src/sm/stressstrainbasevector.C
@@ -62,7 +62,12 @@ StressStrainBaseVector &
 StressStrainBaseVector :: operator = ( const StressStrainBaseVector & src )
 {
     if ( this != & src ) { // beware of s=s;
-        this->values = src.values;
+        #ifdef _USE_EIGEN
+            this->resizeLike(src);
+            for(Eigen::Index i=0; i<this->size(); i++) (*this)[i]=src[i];
+        #else
+            this->values = src.values;
+        #endif
     }
 
     this->mode = src.mode;

--- a/src/sm/stressvector.C
+++ b/src/sm/stressvector.C
@@ -119,7 +119,7 @@ StressVector :: computePrincipalValues(FloatArray &answer) const
 
         ast = this->at(1) + this->at(2);
         dst = this->at(1) - this->at(2);
-        D = sqrt( dst * dst + 4.0 * this->at(3) * this->at(3) );
+        D = std::sqrt( dst * dst + 4.0 * this->at(3) * this->at(3) );
         answer.at(1) = 0.5 * ( ast + D );
         answer.at(2) = 0.5 * ( ast - D );
     } else {
@@ -294,6 +294,9 @@ StressVector :: computeFirstInvariant() const
     // This function computes the first invariant
     // of the stress vector
     //
+    #ifdef _USE_EIGEN
+        const StressVector& values=*this;
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         // 1d problem
@@ -314,6 +317,9 @@ StressVector :: computeSecondInvariant() const
     // This function computes the second invariant of
     // of the deviatoric stress vector
     //
+    #ifdef _USE_EIGEN
+        const StressVector& values=*this;
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         // 1d problem
@@ -339,6 +345,9 @@ StressVector :: computeThirdInvariant() const
     // This function computes the third invariant
     // of the deviatoric stress vector.
     //
+    #ifdef _USE_EIGEN
+        const StressVector& values=*this;
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         // 1d problem
@@ -385,7 +394,7 @@ StressVector :: computeFirstCoordinate() const
     // This function computes the first Haigh-Westergaard coordinate
     // from the stress state
     //
-    return computeFirstInvariant() / sqrt(3.);
+    return computeFirstInvariant() / std::sqrt(3.);
 }
 
 double
@@ -395,7 +404,7 @@ StressVector :: computeSecondCoordinate() const
     // This function computes the second Haigh-Westergaard coordinate
     // from the deviatoric stress state
     //
-    return sqrt( 2. * computeSecondInvariant() );
+    return std::sqrt( 2. * computeSecondInvariant() );
 }
 
 double
@@ -409,7 +418,7 @@ StressVector :: computeThirdCoordinate() const
     if ( computeSecondInvariant() == 0. ) {
         c1 = 0.0;
     } else {
-        c1 = ( 3. * sqrt(3.) / 2. ) * computeThirdInvariant() / ( pow( computeSecondInvariant(), ( 3. / 2. ) ) );
+        c1 = ( 3. * std::sqrt(3.) / 2. ) * computeThirdInvariant() / ( std::pow( computeSecondInvariant(), ( 3. / 2. ) ) );
     }
 
     if ( c1 > 1.0 ) {
@@ -430,6 +439,9 @@ StressVector :: applyElasticCompliance(StrainVector &strain, const double EModul
     // This function multiplies the receiver by the elastic compliance matrix
     // and stores the result in strain
     //
+    #ifdef _USE_EIGEN
+        const StressVector& values=*this;
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         strain(0) = values [ 0 ] / EModulus;
@@ -470,6 +482,9 @@ StressVector :: applyDeviatoricElasticCompliance(StrainVector &strain,
     //
     // This function applies the elastic compliance to the deviatoric strain vector
     //
+    #ifdef _USE_EIGEN
+        const StressVector& values=*this;
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         OOFEM_ERROR("No Split for 1D");
@@ -502,24 +517,27 @@ StressVector :: computeStressNorm() const
     //
     // This function computes the tensorial Norm of the stress in engineering notation
     //
+    #ifdef _USE_EIGEN
+        const StressVector& values=*this;
+    #endif
     MaterialMode myMode = giveStressStrainMode();
     if ( myMode == _1dMat ) {
         // 1d problem
         return fabs(values [ 0 ]);
     } else if ( myMode == _PlaneStress ) {
         // 2d problem: plane stress
-        return sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + 2. * values [ 2 ] * values [ 2 ]);
+        return std::sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + 2. * values [ 2 ] * values [ 2 ]);
     } else if ( myMode == _PlaneStrain ) {
         //  plane strain or axisymmetry
-        return sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] +
+        return std::sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] +
                     2. * values [ 3 ] * values [ 3 ]);
     } else if ( myMode == _PlaneStrainGrad ) {
         //  plane strain or axisymmetry
-        return sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] +
+        return std::sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] +
                     2. * values [ 3 ] * values [ 3 ]);
     } else {
         // 3d problem
-        return sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] +
+        return std::sqrt(values [ 0 ] * values [ 0 ] + values [ 1 ] * values [ 1 ] + values [ 2 ] * values [ 2 ] +
                     2. * values [ 3 ] * values [ 3 ] + 2. * values [ 4 ] * values [ 4 ] + 2. * values [ 5 ] * values [ 5 ]);
     }
 }

--- a/src/sm/transversereinfconstraint.C
+++ b/src/sm/transversereinfconstraint.C
@@ -143,9 +143,7 @@ void TransverseReinfConstraint :: assembleVector(FloatArray &answer, TimeStep *t
                 loc=loc_s;
                 loc.followedBy(loc_c);
 
-                u.resize(u_s.size()+u_c.size());
-                u.copySubVector(u_s,1);
-                u.copySubVector(u_c,u_s.size()+1);
+                u=FloatArray::fromConcatenated({u_s,u_c});
 
                 //Compute the stiffness matrix expansion
                 this->integrateTangent(Klam, es, ec, boundary);

--- a/src/sm/transversereinfconstraint.C
+++ b/src/sm/transversereinfconstraint.C
@@ -143,8 +143,9 @@ void TransverseReinfConstraint :: assembleVector(FloatArray &answer, TimeStep *t
                 loc=loc_s;
                 loc.followedBy(loc_c);
 
-                u=u_s;
-                u.append(u_c);
+                u.resize(u_s.size()+u_c.size());
+                u.copySubVector(u_s,1);
+                u.copySubVector(u_c,u_s.size()+1);
 
                 //Compute the stiffness matrix expansion
                 this->integrateTangent(Klam, es, ec, boundary);

--- a/src/sm/xfem/enrichmentitems/delamination.C
+++ b/src/sm/xfem/enrichmentitems/delamination.C
@@ -364,7 +364,7 @@ void Delamination :: initializeFrom(InputRecord &ir)
     // update: csnum is now an IntArray of cross sections viable for delamination
     bool checkCS = false; 
     double totalThickness(0.0);
-    FloatArray layerThicknesses;
+    std::vector<double> layerThicknesses;
     int numberOfLayers(0);
     for (int iCS : this->crossSectionNum) {
         LayeredCrossSection *layeredCS = dynamic_cast< LayeredCrossSection * >( this->giveDomain()->giveCrossSection(iCS) );
@@ -397,12 +397,12 @@ void Delamination :: initializeFrom(InputRecord &ir)
         for ( int i = 1 ; i <= numberOfLayers ; i++) {
             double layerThickness = layeredCS->giveLayerThickness(i);
             if (checkCS) {
-                if ( layerThickness != layerThicknesses.at(i) ) {
+                if ( layerThickness != layerThicknesses[i-1] ) {
                     throw ValueInputException(ir, _IFT_Delamination_csnum, "Delamination cross section have different layer thicknesses");
                 }
-                layerThicknesses.at(i) = layerThickness;
+                layerThicknesses[i-1] = layerThickness;
             } else {
-                layerThicknesses.append(layeredCS->giveLayerThickness(i));
+                layerThicknesses.push_back(layeredCS->giveLayerThickness(i));
             }
         }
 


### PR DESCRIPTION
In reference to #174, this implements the first three sub-points: 

- remove any use of `reserve`/`append`/`push_back` for `FloatArray`
- rename `FloatArray::isFinite` to `FloatArray::isAllFinite`
- remove `FloatArray::hardResize`
- replace `RESIZE` and `FAST_RESIZE` macros byprivate `_internal_resize` method in array/matrix
- use `normalize_giveNorm` where return value matters, `normalize` otherwise
- a few warnings fixed

All tests are passing.

