### PR TITLE
Optionally use Eigen via _USE_EIGEN (all tests passing, changes minimized)

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -26,14 +26,19 @@ pyodide:
 	cd bindings/python/tests; python -m pytest
 shared:
 	mkdir -p build-shared
-	cmake -Bbuild-shared -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=1 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
+	cmake -Bbuild-shared -H. -GNinja  -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=1 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
 	ninja -C build-shared/
 	ctest --test-dir build-shared/ --parallel=16 --output-on-failure
+eigen:
+	mkdir -p build-eigen
+	cmake -Bbuild-eigen -H. -GNinja  -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_EIGEN=1 -DUSE_PYBIND_BINDINGS=0 -DUSE_PYTHON_EXTENSION=0 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
+	ninja -C build-eigen/
+	ctest --test-dir build-eigen/ --parallel=16 --output-on-failure
 notshared:
 	mkdir -p build-notshared
 	cmake -Bbuild-notshared -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_PYTHON_EXTENSION=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
 	ninja -C build-notshared/
-	ctest --test-dir build-notshared/ --parallel=16
+	ctest --verbose --test-dir build-notshared/ --parallel=16
 nanobind:
 	cmake -Bbuild-nanobind -H. -GNinja -DCMAKE_BUILD_TYPE=Release -DUSE_PYBIND_BINDINGS=1 -DUSE_NANOBIND=1 -DUSE_SHARED_LIB=0 -DUSE_OOFEM_EXE=1 -DUSE_SM=1 -DUSE_TM=1 -DUSE_MPM=1
 	ninja -C build-nanobind

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ option (USE_PYTHON_EXTENSION "Enable Python extension for exposing C++ code to p
 option (USE_HDF5 "HDF5 support" OFF)
 option (USE_MPM "Enable experimental multiphysics module" OFF)
 option (USE_OOFEM_EXE "Build oofem executable" ON)
+OPTION (USE_EIGEN "Use Eigen instead of home-made array classes (experimental)" OFF)
 
 if (USE_MPI_PARALLEL)
     add_definitions (-D__MPI_PARALLEL_MODE)
@@ -317,17 +318,11 @@ endif ()
 ######################## External libraries ###########################
 #######################################################################
 
-#if (USE_BOOST) 
-#    set (CMAKE_LIBRARY_DIR ${BOOST_DIR})
-#    find_package (BOOST REQUIRED)
-#    list (APPEND EXT_LIBS ${BOOST_LIBRARIES})
-#    if (BOOST_DIR)
-#        include_directories ("${BOOST_DIR}")
-#        list (APPEND MODULE_LIST "BOOST")
-#     endif ()
-#
-#    add_definitions (-D__BOOST_MODULE)
-#endif ()
+if (USE_EIGEN)
+    add_definitions(-D_USE_EIGEN)
+    find_package(Eigen3 REQUIRED NO_MODULE)
+    link_libraries(Eigen3::Eigen)
+endif()
 
 if (USE_LAPACK)
     set (CMAKE_LIBRARY_DIR ${LAPACK_DIR})

--- a/src/fm/Materials/fluiddynamicmaterial.C
+++ b/src/fm/Materials/fluiddynamicmaterial.C
@@ -106,11 +106,11 @@ FluidDynamicMaterial :: computeTangents3D(MatResponseMode mode, GaussPoint *gp, 
 FluidDynamicMaterial::Tangents<3>
 FluidDynamicMaterial :: computeTangents2D(MatResponseMode mode, GaussPoint *gp, TimeStep *tStep) const
 {
-    auto t = this->computeTangents3D(mode, gp, tStep);
+    Tangents<6> t = this->computeTangents3D(mode, gp, tStep);
 
-    auto dsdd = t.dsdd({0, 1, 5}, {0, 1, 5});
-    auto dsdp = t.dsdp[{0, 1, 5}];
-    auto dedd = t.dedd[{0, 1, 5}];
+    FloatMatrixF<3,3> dsdd = t.dsdd({0, 1, 5}, {0, 1, 5});
+    FloatArrayF<3> dsdp = t.dsdp[{0, 1, 5}];
+    FloatArrayF<3> dedd = t.dedd[{0, 1, 5}];
     return {dsdd, dsdp, dedd, t.dedp};
 }
 

--- a/src/mpm/termlibrary.C
+++ b/src/mpm/termlibrary.C
@@ -227,8 +227,8 @@ void NTamTBTerm::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint* gp
     this->testField->interpolation->evalN(Np, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
     m.times(e.giveCrossSection()->giveMaterial(gp)->giveCharacteristicValue(aType, gp, tstep));
     this->grad(B, this->field, this->field->interpolation, e, gp->giveNaturalCoordinates(), mmode);
-    mb.beTProductOf(m, B);
-    FloatMatrix Npm(Np);
+    mb.beTProductOf(FloatMatrix::fromArray(m), B);
+    FloatMatrix Npm=FloatMatrix::fromArray(Np);
     answer.beProductOf(Npm, mb);
 }
 

--- a/src/mpm/termlibrary2.C
+++ b/src/mpm/termlibrary2.C
@@ -111,7 +111,7 @@ NTBdivTerm::NTBdivTerm (const Variable *testField, const Variable* unknownField,
 void NTBdivTerm::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint* gp, TimeStep* tstep) const {
     FloatArray Np;
     this->testField->interpolation->evalN(Np, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
-    FloatMatrix Npm(Np), B;   
+    FloatMatrix Npm=FloatMatrix::fromArray(Np), B;
     deltaB(B, this->field, this->field->interpolation, e, gp->giveNaturalCoordinates(), gp->giveMaterialMode());
     answer.beTProductOf(Npm,B);
 }
@@ -143,7 +143,7 @@ void deltaBTfiNpTerm::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoin
     deltaB(B, this->testField, this->testField->interpolation, e, gp->giveNaturalCoordinates(), gp->giveMaterialMode());
     double vf = evalVolumeFraction(this->volumeFraction, e, gp->giveNaturalCoordinates(), tstep);
     this->field->interpolation->evalN(Np, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
-    FloatMatrix Npm(Np);
+    FloatMatrix Npm=FloatMatrix::fromArray(Np);
     answer.beTProductOf(B,Npm);
     answer.times(vf);
 }
@@ -177,8 +177,8 @@ void NdTdvfNpTerm::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint* 
     e.getUnknownVector(rvf, this->volumeFraction, VM_TotalIntrinsic, tstep);
     dvf.beTProductOf(dndx, rvf);
     this->field->interpolation->evalN(Np, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
-    FloatMatrix Npm(Np);
-    help.beTProductOf(N,dvf); // Nv * dv
+    FloatMatrix Npm=FloatMatrix::fromArray(Np);
+    help.beTProductOf(N,FloatMatrix::fromArray(dvf)); // Nv * dv
     answer.beProductOf(help, Npm);
 }
 
@@ -303,7 +303,7 @@ void deltaBTNpTerm::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint*
     FloatMatrix B;   
     deltaB(B, this->testField, this->testField->interpolation, e, gp->giveNaturalCoordinates(), gp->giveMaterialMode());
     this->field->interpolation->evalN(Np, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
-    FloatMatrix Npm(Np);
+    FloatMatrix Npm=FloatMatrix::fromArray(Np);
     answer.beTProductOf(B,Npm);
 }
 

--- a/src/mpm/termlibrary3.C
+++ b/src/mpm/termlibrary3.C
@@ -113,7 +113,7 @@ void BDalphaPiTerm::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint*
 
     DaPI.beProductOf(D, alphaPi);
     BDaPI.beTProductOf(B,DaPI);
-    FloatMatrix Ntm(Nt, true);
+    FloatMatrix Ntm=FloatMatrix::fromArray(Nt, true);
     answer.beProductOf(BDaPI,Ntm);
 
 }
@@ -139,7 +139,7 @@ void BTdSigmadT::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint* gp
     e.giveCrossSection()->giveMaterial(gp)->giveCharacteristicMatrix(D, DSigmaDT, gp, tstep);
     this->field->interpolation->evalN(Nt, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
     evalB(B, this->testField, this->testField->interpolation, e, gp->giveNaturalCoordinates(), gp->giveMaterialMode());
-    FloatMatrix Ntm(Nt, true);
+    FloatMatrix Ntm=FloatMatrix::fromArray(Nt, true);
     DB.beProductOf(D, Ntm);
     //answer.plusProductSymmUpper(B, DB, 1.0);
     answer.beTProductOf(B,DB);

--- a/src/mpm/termlibrary4.C
+++ b/src/mpm/termlibrary4.C
@@ -71,7 +71,7 @@ void dnTaN::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint* gp, Tim
     FloatMatrix dndx;
     this->testField->interpolation->evaldNdx(dndx, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
     this->field->interpolation->evalN(n, gp->giveNaturalCoordinates(), FEIElementGeometryWrapper(&e));
-    FloatMatrix nm(n, true), anm;
+    FloatMatrix nm=FloatMatrix::fromArray(n, true), anm;
     int nsd = this->field->interpolation->giveNsd(e.giveGeometryType());
     FloatMatrix am(nsd,1);
     //a.at(2,1)=1.0; // assume 2d flow for now
@@ -82,7 +82,7 @@ void dnTaN::evaluate_lin (FloatMatrix& answer, MPElement& e, GaussPoint* gp, Tim
     for (int i=1; i<=nsd; i++) {
         am.at(i,1)=a.at(i);
     }
-    anm.beProductOf(a, nm);
+    anm.beProductOf(FloatMatrix::fromArray(a), nm);
     answer.beProductOf(dndx, anm);
 }
 

--- a/src/oofemlib/crosssection.h
+++ b/src/oofemlib/crosssection.h
@@ -267,11 +267,15 @@ public:
     void initializeFrom(InputRecord &ir) override;
     void giveInputRecord(DynamicInputRecord &input) override;
 
+    #pragma GCC diagnostic push
+    /// hidden by virtual oofem::Material* TransportCrossSection::giveMaterial() const
+    #pragma GCC diagnostic ignored "-Woverloaded-virtual"
     /**
      * Returns the material associated with the GP.
      * Default implementation uses gp->giveMaterial() for backwards compatibility, but it should be overloaded in each specialized cross-section.
      */
     virtual Material *giveMaterial(IntegrationPoint *ip) const = 0;
+    #pragma GCC diagnostic pop
 
     /**
      * Stores integration point state to output stream.

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -51,14 +51,6 @@
 #include <fstream>
 #include <iomanip>
 
-#ifdef __LAPACK_MODULE
-extern "C" {
-    extern void dgemv_(const char *trans, const int *m, const int *n, const double *alpha, const double *a, const int *lda, const double *x,
-                       const int *incx, const double *beta, double *y, const int *incy, int aColumns, int xSize, int ySize);
-    // Y = Y + alpha * X
-    extern void daxpy_(const int *n, const double *alpha, const double *x, const int *incx, double *y, const int *incy, int xsize, int ysize);
-}
-#endif
 
 namespace oofem {
 
@@ -81,7 +73,7 @@ void FloatArray :: resizeWithValues(Index n, std::size_t allocChunk)
 
 #endif
 
-    if ( allocChunk > 0 && this->values.capacity() < n ) {
+    if ( allocChunk > 0 && (Index)this->values.capacity() < n ) {
         this->values.reserve(n + allocChunk);
     }
 

--- a/src/oofemlib/floatarray.C
+++ b/src/oofemlib/floatarray.C
@@ -458,12 +458,12 @@ double FloatArray :: dotProduct(const FloatArray &x, Index size) const
 
 double FloatArray :: distance(const FloatArray &x) const
 {
-    return sqrt( this->distance_square(x) );
+    return std::sqrt( this->distance_square(x) );
 }
 
 double FloatArray :: distance(const FloatArray &iP1, const FloatArray &iP2, double &oXi, double &oXiUnbounded) const
 {
-    return sqrt( distance_square(iP1, iP2, oXi, oXiUnbounded) );
+    return std::sqrt( distance_square(iP1, iP2, oXi, oXiUnbounded) );
 }
 
 double FloatArray :: distance_square(const FloatArray &iP1, const FloatArray &iP2, double &oXi, double &oXiUnbounded) const
@@ -472,7 +472,7 @@ double FloatArray :: distance_square(const FloatArray &iP1, const FloatArray &iP
 
     if ( l2 > 0.0 ) {
 
-        const double s = (dot(*this, iP2) - dot(*this, iP1) ) - ( dot(iP1, iP2) - dot(iP1, iP1) );
+        const double s = (oofem::dot(*this, iP2) - oofem::dot(*this, iP1) ) - ( oofem::dot(iP1, iP2) - oofem::dot(iP1, iP1) );
 
         if ( s < 0.0 ) {
             // X is closest to P1
@@ -670,7 +670,7 @@ void FloatArray :: negated()
 void FloatArray :: printYourself() const
 // Prints the receiver on screen.
 {
-    printf("FloatArray of size : %d \n", this->giveSize());
+    printf("FloatArray of size : %d \n", (int)this->giveSize());
     for ( double x: *this ) {
         printf( "%10.3e  ", x );
     }
@@ -682,7 +682,7 @@ void FloatArray :: printYourself() const
 void FloatArray :: printYourself(const std::string &name) const
 // Prints the receiver on screen.
 {
-    printf("%s (%d): \n", name.c_str(), this->giveSize());
+    printf("%s (%d): \n", name.c_str(), (int)this->giveSize());
     for ( double x: *this ) {
         printf( "%10.3e  ", x );
     }
@@ -765,7 +765,7 @@ double FloatArray :: normalize_giveNorm()
 
 double FloatArray :: computeNorm() const
 {
-    return sqrt( this->computeSquaredNorm() );
+    return std::sqrt( this->computeSquaredNorm() );
 }
 
 
@@ -1067,7 +1067,7 @@ std :: ostream &operator << ( std :: ostream & out, const FloatArray & x )
 void FloatArray :: power(const double exponent)
 {
     for ( double &x : *this ) {
-        x = pow(x, exponent);
+        x = std::pow(x, exponent);
     }
 }
 

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -557,17 +557,22 @@ public:
     //@}
 };
 
-///@name IML compatibility
-//@{
-/// Vector multiplication by scalar
-OOFEM_EXPORT FloatArray &operator *= ( FloatArray & x, const double & a );
-OOFEM_EXPORT FloatArray operator *( const double & a, const FloatArray & x );
-OOFEM_EXPORT FloatArray operator *( const FloatArray & x, const double & a );
-OOFEM_EXPORT FloatArray operator + ( const FloatArray & x, const FloatArray & y );
-OOFEM_EXPORT FloatArray operator - ( const FloatArray & x, const FloatArray & y );
-OOFEM_EXPORT FloatArray &operator += ( FloatArray & x, const FloatArray & y );
-OOFEM_EXPORT FloatArray &operator -= ( FloatArray & x, const FloatArray & y );
+#ifndef _USE_EIGEN
+    ///@name IML compatibility: operators
+    //@{
+    OOFEM_EXPORT FloatArray &operator *= ( FloatArray & x, const double & a );
+    OOFEM_EXPORT FloatArray operator *( const double & a, const FloatArray & x );
+    OOFEM_EXPORT FloatArray operator *( const FloatArray & x, const double & a );
+    OOFEM_EXPORT FloatArray operator + ( const FloatArray & x, const FloatArray & y );
+    OOFEM_EXPORT FloatArray operator - ( const FloatArray & x, const FloatArray & y );
+    OOFEM_EXPORT FloatArray &operator += ( FloatArray & x, const FloatArray & y );
+    OOFEM_EXPORT FloatArray &operator -= ( FloatArray & x, const FloatArray & y );
+    //@}
+#endif
 
+
+///@name IML compatibility: functions
+//@{
 OOFEM_EXPORT double norm(const FloatArray &x);
 OOFEM_EXPORT double norm_square(const FloatArray &x);
 OOFEM_EXPORT double dot(const FloatArray &x, const FloatArray &y);
@@ -577,6 +582,7 @@ OOFEM_EXPORT bool isfinite(const FloatArray &x);
 OOFEM_EXPORT bool iszero(const FloatArray &x);
 OOFEM_EXPORT double sum(const FloatArray & x);
 OOFEM_EXPORT double product(const FloatArray & x);
+//@}
 
 
 inline static FloatArray Vec1(const double& a){ return FloatArray::fromIniList({a}); }

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -84,7 +84,8 @@ template<std::size_t N> class FloatArrayF;
  */
 class OOFEM_EXPORT FloatArray
 {
-    void _resize_internal(size_t newsize);
+    typedef int Index;
+    void _resize_internal(Index newsize);
 protected:
     /// Stored values.
     std::vector< double > values;
@@ -142,24 +143,24 @@ public:
      * position of the receiver. Provides 1-based indexing access.
      * @param i Position of coefficient in array.
      */
-    inline double &at(std::size_t i)
+    inline double &at(Index i)
     {
 #ifndef NDEBUG
         this->checkBounds( i );
 #endif
-        return values [ i - 1 ];
+        return (*this)[ i - 1 ];
     }
     /**
      * Coefficient access function. Returns l-value of coefficient at given
      * position of the receiver. Provides 1-based indexing access.
      * @param i Position of coefficient in array.
      */
-    inline double at(std::size_t i) const
+    inline double at(Index i) const
     {
 #ifndef NDEBUG
         this->checkBounds( i );
 #endif
-        return values [ i - 1 ];
+        return (*this)[ i - 1 ];
     }
 
     /**
@@ -167,11 +168,11 @@ public:
      * position of the receiver. Provides 0-based indexing access.
      * @param i Position of coefficient in array.
      */
-    inline double &operator() (std::size_t i) { return this->operator[](i); }
-    inline double &operator[] (std::size_t i)
+    inline double &operator() (Index i) { return this->operator[](i); }
+    inline double &operator[] (Index i)
     {
 #ifndef NDEBUG
-        if ( i >= values.size()) {
+        if ( i >= size()) {
             OOFEM_ERROR( "array error on index : %d >= %d", i, this->giveSize() );
         }
 #endif
@@ -182,10 +183,10 @@ public:
      * position of the receiver. Provides 0-based indexing access.
      * @param i Position of coefficient in array.
      */
-    inline const double &operator() (std::size_t i) const { return this->operator[](i); } 
-    inline const double &operator[] (std::size_t i) const {
+    inline const double &operator() (Index i) const { return this->operator[](i); } 
+    inline const double &operator[] (Index i) const {
 #ifndef NDEBUG
-        if ( i >= values.size() ) {
+        if ( i >= size() ) {
             OOFEM_ERROR( "array error on index : %d >= %d", i, this->giveSize() );
         }
 #endif
@@ -197,12 +198,12 @@ public:
      * mismatch found.
      * @param i Required size of receiver.
      */
-    void checkBounds(std::size_t i) const
+    void checkBounds(Index i) const
     {
         if ( i <= 0 ) {
             OOFEM_ERROR("array error on index : %d <= 0", i);
-        } else if ( i > values.size()) {
-            OOFEM_ERROR("array error on index : %d > %d", i, this->giveSize());
+        } else if ( i > size()) {
+            OOFEM_ERROR("array error on index : %d > %d", i, this->size());
         }
     }
     /**
@@ -218,28 +219,29 @@ public:
      * @param s New size.
      * @param allocChunk Additional space to allocate.
      */
-    void resizeWithValues(std::size_t s, std::size_t allocChunk = 0);
+    void resizeWithValues(Index s, std::size_t allocChunk = 0);
     /**
      * Resizes receiver towards requested size. Array is zeroed.
      * @param s New size.
      */
-    void resize(int s);
+    void resize(Index s);
     /**
      * Clears receiver (zero size).
      * Same effect as resizing to zero, but has a clearer meaning and intent when used.
      */
-    void clear() { this->values.clear(); }
+    void clear() { this->resize(0); }
     /**
      * Returns nonzero if all coefficients of the receiver are 0, else returns zero.
      */
     bool containsOnlyZeroes() const;
     /// Returns the size of receiver.
-    int giveSize() const { return (int)this->values.size(); }
-    std::size_t size() const { return this->values.size(); }
+    //[[deprecated("use size() instead.")]]
+    Index giveSize() const { return (Index)this->values.size(); }
+    Index size() const { return this->values.size(); }
     /// Returns true if receiver is not empty.
-    bool isNotEmpty() const { return !this->values.empty(); }
+    bool isNotEmpty() const { return size()>0; }
     /// Returns true if receiver is empty.
-    bool isEmpty() const { return this->values.empty(); }
+    bool isEmpty() const { return size()==0; }
     /**
      * Switches the sign of every coefficient of receiver.
      * @return receiver.
@@ -353,7 +355,7 @@ public:
      * @param b Array which receiver comes from.
      * @param n Only first n entries are taken.
      */
-    void beDifferenceOf(const FloatArray &a, const FloatArray &b, std::size_t n);
+    void beDifferenceOf(const FloatArray &a, const FloatArray &b, Index n);
     /**
      * Extract sub vector form src array and stores the result into receiver.
      * @param src source vector for sub vector
@@ -368,7 +370,7 @@ public:
      * @param src Sub-vector to be added.
      * @param si Determines the position (receiver's 1-based index) of first src value to be added.
      */
-    void addSubVector(const FloatArray &src, std::size_t si);
+    void addSubVector(const FloatArray &src, Index si);
     /**
      * Assembles the array fe (typically, the load vector of a finite
      * element) into the receiver, using loc as location array.
@@ -434,7 +436,7 @@ public:
      * @param x Vector to contract to receiver.
      * @param size Number of elements to contract. May not be larger than
      */
-    double dotProduct(const FloatArray &x, std::size_t size) const;
+    double dotProduct(const FloatArray &x, Index size) const;
 
     /**
      * Normalizes receiver. Euclidean norm is used, after operation receiver
@@ -517,7 +519,7 @@ public:
     /**
      * Reciever will be set to a given row in a matrix
      */
-    void beRowOf(const FloatMatrix &mat, std::size_t row);
+    void beRowOf(const FloatMatrix &mat, Index row);
     
     contextIOResultType storeYourself(DataStream &stream) const;
     contextIOResultType restoreYourself(DataStream &stream);

--- a/src/oofemlib/floatarray.h
+++ b/src/oofemlib/floatarray.h
@@ -39,6 +39,7 @@
 #include "contextioresulttype.h"
 #include "contextmode.h"
 #include "error.h"
+#include "numerics.h"
 
 #include <initializer_list>
 #include <vector>
@@ -84,7 +85,6 @@ template<std::size_t N> class FloatArrayF;
  */
 class OOFEM_EXPORT FloatArray
 {
-    typedef int Index;
     void _resize_internal(Index newsize);
 protected:
     /// Stored values.
@@ -535,8 +535,6 @@ public:
     FloatArray &operator = ( const double & );
     //@}
 };
-
-const FloatArray ZeroVector = {0.0,0.0,0.0};
 
 ///@name IML compatibility
 //@{

--- a/src/oofemlib/floatarrayf.h
+++ b/src/oofemlib/floatarrayf.h
@@ -56,7 +56,24 @@ namespace oofem {
  */
 template<std::size_t N>
 class OOFEM_EXPORT FloatArrayF
+#ifdef _USE_EIGEN
+    : public VectorNd<N>
+#endif
 {
+#ifdef _USE_EIGEN
+public:
+    OOFEM_EIGEN_DERIVED(FloatArrayF,VectorNd<N>);
+    Index size() const { return VectorNd<N>::size(); }
+    const double *data() const { return VectorNd<N>::data(); }
+    double *data() {  return VectorNd<N>::data(); }
+
+    template<typename... V, class = typename std::enable_if_t<sizeof...(V) == N>>
+    FloatArrayF(V... x) { this->array()=NaN; /* TODO */}
+
+    // since we re-declare operator[ {...} ] below, we need to include those as well for overload resolution
+    double &operator[] (Index i){ return VectorNd<N>::operator[](i); }
+    const double &operator[] (Index i) const { return VectorNd<N>::operator[](i); }
+#else
 protected:
     /// Stored values.
     std::array< double, N > values;
@@ -91,32 +108,6 @@ public:
     /// Assignment operator
     void operator = (const FloatArrayF<N> &src) { values = src.values; }
 
-    /**
-     * Coefficient access function. Returns value of coefficient at given
-     * position of the receiver. Provides 1-based indexing access.
-     * @param i Position of coefficient in array.
-     */
-    inline double &at(std::size_t i)
-    {
-#ifndef NDEBUG
-        return values.at( i - 1 );
-#else
-        return values [ i - 1 ];
-#endif
-    }
-    /**
-     * Coefficient access function. Returns l-value of coefficient at given
-     * position of the receiver. Provides 1-based indexing access.
-     * @param i Position of coefficient in array.
-     */
-    inline double at(std::size_t i) const
-    {
-#ifndef NDEBUG
-        return values.at( i - 1 );
-#else
-        return values [ i - 1 ];
-#endif
-    }
 
     /**
      * Coefficient access function. Returns value of coefficient at given
@@ -125,25 +116,30 @@ public:
      */
     inline double &operator[] (std::size_t i)
     {
-#ifndef NDEBUG
+        #ifndef NDEBUG
         return values.at( i );
-#else
+        #else
         return values [ i ];
-#endif
+        #endif
     }
     /**
      * Coefficient access function. Returns value of coefficient at given
      * position of the receiver. Provides 0-based indexing access.
      * @param i Position of coefficient in array.
      */
-    inline const double &operator[] (std::size_t i) const { 
-#ifndef NDEBUG
+    inline const double &operator[] (std::size_t i) const {
+        #ifndef NDEBUG
         return values.at( i );
-#else
+        #else
         return values [ i ];
-#endif
+        #endif
     }
+    /// Returns the size of receiver.
+    int size() const { return N; }
+    const double *data() const { return values.data(); }
+    double *data() { return values.data(); }
 
+#endif
     /**
      * Multi-indexing to select sub-vectors,
      * @param c Position of coefficient in array.
@@ -153,10 +149,23 @@ public:
     {
         FloatArrayF<M> x;
         for ( std::size_t i = 0; i < M; ++i ) {
-            x[i] = values[ c[i] ];
+            x[i] = (*this)[ c[i] ];
         }
         return x;
     }
+
+    /**
+     * Coefficient access function. Returns value of coefficient at given
+     * position of the receiver. Provides 1-based indexing access.
+     * @param i Position of coefficient in array.
+     */
+    inline double &at(std::size_t i) { return (*this)[i-1]; }
+    /**
+     * Coefficient access function. Returns l-value of coefficient at given
+     * position of the receiver. Provides 1-based indexing access.
+     * @param i Position of coefficient in array.
+     */
+    inline double at(std::size_t i) const { return (*this)[i-1]; }
 
     /// Assign x into self.
     template<size_t M>
@@ -175,11 +184,8 @@ public:
             (*this)[c[i]] += x[i];
         }
     }
-    
     /// Returns the size of receiver.
-    int size() const { return N; }
-    /// Returns the size of receiver.
-    int giveSize() const { return N; }
+    int giveSize() const { return size(); }
     /**
      * Print receiver on stdout with custom name.
      * @param name Display name of reciever.
@@ -196,8 +202,8 @@ public:
      * Gives the pointer to the raw data, breaking encapsulation.
      * @return Pointer to values of array
      */
-    const double *givePointer() const { return values.data(); }
-    double *givePointer() { return values.data(); }
+    const double *givePointer() const { return data(); }
+    double *givePointer() { return data(); }
 
     contextIOResultType storeYourself(DataStream &stream) const
     {

--- a/src/oofemlib/floatarrayf.h
+++ b/src/oofemlib/floatarrayf.h
@@ -510,13 +510,13 @@ FloatArrayF<N> min(const FloatArrayF<N> &a, const FloatArrayF<N> &b)
 const FloatArrayF<6> I6 {1., 1., 1., 0., 0., 0.};
 
 /// Convert stress to strain Voigt form
-inline FloatArrayF<6> to_voigt_strain(const FloatArrayF<6> &s)
+inline FloatArrayF<6> to_voigt_strain_6(const FloatArrayF<6> &s)
 {
     return {s[0], s[1], s[2], 0.5*s[3], 0.5*s[4], 0.5*s[5]};
 }
 
 /// Convert strain to stress Voigt form
-inline FloatArrayF<6> to_voigt_stress(const FloatArrayF<6> &e)
+inline FloatArrayF<6> to_voigt_stress_6(const FloatArrayF<6> &e)
 {
     return {e[0], e[1], e[2], 2*e[3], 2*e[4], 2*e[5]};
 }

--- a/src/oofemlib/floatarrayf.h
+++ b/src/oofemlib/floatarrayf.h
@@ -67,8 +67,16 @@ public:
     const double *data() const { return VectorNd<N>::data(); }
     double *data() {  return VectorNd<N>::data(); }
 
-    template<typename... V, class = typename std::enable_if_t<sizeof...(V) == N>>
-    FloatArrayF(V... x) { this->array()=NaN; /* TODO */}
+    template<
+        typename... Args,
+        class = typename std::enable_if_t<sizeof...(Args) == N>,
+        class = std::enable_if_t<(std::conjunction_v<std::is_same<double, Args>...>)>
+    >
+    FloatArrayF(Args... args){
+        std::initializer_list<double> ini{ args ... };
+        int i=0; for(const double& x: ini){ (*this)[i++]=x; }
+    }
+
 
     // since we re-declare operator[ {...} ] below, we need to include those as well for overload resolution
     double &operator[] (Index i){ return VectorNd<N>::operator[](i); }

--- a/src/oofemlib/floatmatrix.C
+++ b/src/oofemlib/floatmatrix.C
@@ -48,19 +48,6 @@
 #include <iomanip>
 #include <numeric>
 
-namespace oofem{
-void FloatMatrix::_resize_internal(int nr, int nc)
-    { \
-        this->nRows = nr; this->nColumns = nc; \
-        std::size_t nsize = this->nRows * this->nColumns; \
-        if ( nsize < this->values.size() ) { \
-            this->values.resize(nsize); \
-        } else if ( nsize > this->values.size() ) { \
-            this->values.assign(nsize, 0.); \
-        } \
-    }
-};
-
 
 
 // Some forward declarations for LAPACK. Remember to append the underscore to the function name.
@@ -105,56 +92,101 @@ extern void dscal_(const int *n, const double *alpha, const double *x, const int
 
 
 namespace oofem {
+
+
+#define _LOOP_MATRIX(r,c) for(Index c=0; c<cols(); c++) for(Index r=0; r<rows(); r++)
+
+
+void FloatMatrix::_resize_internal(int nr, int nc){
+    this->nRows = nr; this->nColumns = nc;
+    std::size_t nsize = this->nRows * this->nColumns;
+    if ( nsize < this->values.size() ) {
+        this->values.resize(nsize);
+    } else if ( nsize > this->values.size() ) {
+        this->values.assign(nsize, 0.);
+    }
+};
+
+
+void FloatMatrix :: resize(Index rows, Index columns)
+//
+// resizes receiver, all data will be lost
+//
+{
+    this->nRows = rows;
+    this->nColumns = columns;
+    this->values.assign(rows * columns, 0.);
+}
+
+
+void FloatMatrix :: resizeWithData(Index rows, Index columns)
+//
+// resizes receiver, all data kept
+//
+{
+    // Check of resize if necessary at all.
+    if ( rows == this->rows() && columns == this->cols() ) {
+        return;
+    }
+
+    FloatMatrix old( std :: move(* this) );
+
+    this->nRows = rows;
+    this->nColumns = columns;
+    this->values.resize(rows * columns);
+
+    Index ii = min( rows, (Index)old.rows() );
+    Index jj = min( columns, (Index)old.cols() );
+    // copy old values if possible
+    for (Index i = 1; i <= ii; i++ ) {
+        for (Index j = 1; j <= jj; j++ ) {
+            this->at(i, j) = old.at(i, j);
+        }
+    }
+}
+
+
+
+
 FloatMatrix :: FloatMatrix(const FloatArray &vector, bool transpose)
 //
 // constructor : creates (vector->giveSize(),1) FloatMatrix
 // if transpose = 1 creates (1,vector->giveSize()) FloatMatrix
 //
 {
-    if ( transpose ) {
-        nRows = 1; // column vector
-        nColumns = vector.giveSize();
-    } else {
-        nRows = vector.giveSize(); // row vector- default
-        nColumns = 1;
-    }
-
-    values = vector.values;
+    this->initFromVector(vector,transpose);
 }
 
 
 FloatMatrix :: FloatMatrix(std :: initializer_list< std :: initializer_list< double > >mat)
 {
     _resize_internal( mat.size(), mat.begin()->size() );
-    auto p = this->values.begin();
+    Index c=0;
     for ( auto col : mat ) {
 #if DEBUG
         if ( this->nRows != col.size() ) {
             OOFEM_ERROR("Initializer list has inconsistent column sizes.");
         }
 #endif
-        for ( auto x : col ) {
-            * p = x;
-            p++;
-        }
+        for(size_t r=0; r<col.size(); r++) (*this)(r,c);
+        c++;
     }
 }
+
 
 
 FloatMatrix &FloatMatrix :: operator = ( std :: initializer_list< std :: initializer_list< double > >mat )
 {
     _resize_internal( ( int ) mat.begin()->size(), ( int ) mat.size() );
-    auto p = this->values.begin();
+    Index c=0;
     for ( auto col : mat ) {
 #if DEBUG
-        if ( this->nRows != col.size() ) {
+        if ( rows() != (Index) col.size() ) {
                 OOFEM_ERROR("Initializer list has inconsistent column sizes.");
         }
 #endif
-        for ( auto x : col ) {
-            * p = x;
-            p++;
-        }
+        for(size_t r=0; r<col.size(); r++) (*this)(r,c);
+        c++;
     }
 
     return * this;
@@ -164,24 +196,21 @@ FloatMatrix &FloatMatrix :: operator = ( std :: initializer_list< std :: initial
 FloatMatrix &FloatMatrix :: operator = ( std :: initializer_list< FloatArray >mat )
 {
     _resize_internal( mat.begin()->giveSize(), ( int ) mat.size() );
-    auto p = this->values.begin();
+    Index c=0;
     for ( auto col : mat ) {
 #if DEBUG
-        if ( this->nRows != col.size() ) {
+        if ( rows() != (Index) col.size() ) {
                 OOFEM_ERROR("Initializer list has inconsistent column sizes.");
         }
 #endif
-        for ( auto x : col ) {
-            * p = x;
-            p++;
-        }
+        for(Index r=0; r<col.size(); r++) (*this)(r,c);
+        c++;
     }
 
     return * this;
 }
 
-
-void FloatMatrix :: checkBounds(std::size_t i, std::size_t j) const
+void FloatMatrix :: checkBounds(Index i, Index j) const
 // Checks that the receiver includes a position (i,j).
 {
     if ( i <= 0 ) {
@@ -191,20 +220,19 @@ void FloatMatrix :: checkBounds(std::size_t i, std::size_t j) const
         OOFEM_ERROR("matrix error on columns : %d < 0", j);
     }
 
-    if ( i > nRows ) {
-        OOFEM_ERROR("matrix error on rows : %d > %d", i, nRows);
+    if ( i > rows() ) {
+        OOFEM_ERROR("matrix error on rows : %d > %d", i, rows());
     }
 
-    if ( j > nColumns ) {
-		printf("APA \n");
-        OOFEM_ERROR("matrix error on columns : %d > %d", j, nColumns);
+    if ( j > cols() ) {
+        OOFEM_ERROR("matrix error on columns : %d > %d", j, cols());
     }
 }
 
 bool FloatMatrix :: isAllFinite() const
 {
-    for (double val : values) {
-        if ( !std::isfinite(val) ) {
+    for(Index r=0; r<rows(); r++) for(Index c=0; c<cols(); c++){
+        if ( !std::isfinite((*this)(r,c)) ) {
             return false;
         }
     }
@@ -214,7 +242,7 @@ bool FloatMatrix :: isAllFinite() const
 
 void FloatMatrix :: assemble(const FloatMatrix &src, const IntArray &loc)
 {
-    std::size_t ii, jj, size = src.giveRowSize();
+    std::size_t ii, jj, size = src.rows();
 
 #ifndef NDEBUG
     if ( size != loc.size() ) {
@@ -329,11 +357,11 @@ void FloatMatrix :: beProductOf(const FloatMatrix &aMatrix, const FloatMatrix &b
 // Receiver = aMatrix * bMatrix
 {
 #  ifndef NDEBUG
-    if ( aMatrix.nColumns != bMatrix.nRows ) {
-        OOFEM_ERROR("error in product A*B : dimensions do not match, A(*,%d), B(%d,*)", aMatrix.nColumns, bMatrix.nRows);
+    if ( aMatrix.cols() != bMatrix.rows() ) {
+        OOFEM_ERROR("error in product A*B : dimensions do not match, A(*,%d), B(%d,*)", aMatrix.cols(), bMatrix.rows());
     }
 #  endif
-    _resize_internal(aMatrix.nRows, bMatrix.nColumns);
+    _resize_internal(aMatrix.rows(), bMatrix.cols());
 #  ifdef __LAPACK_MODULE
     double alpha = 1., beta = 0.;
     dgemm_("n", "n", & this->nRows, & this->nColumns, & aMatrix.nColumns,
@@ -341,10 +369,10 @@ void FloatMatrix :: beProductOf(const FloatMatrix &aMatrix, const FloatMatrix &b
            & beta, this->givePointer(), & this->nRows,
            aMatrix.nColumns, bMatrix.nColumns, this->nColumns);
 #  else
-    for ( std::size_t i = 1; i <= aMatrix.nRows; i++ ) {
-        for ( std::size_t j = 1; j <= bMatrix.nColumns; j++ ) {
+    for ( Index i = 1; i <= aMatrix.rows(); i++ ) {
+        for ( Index j = 1; j <= bMatrix.cols(); j++ ) {
             double coeff = 0.;
-            for ( std::size_t k = 1; k <= aMatrix.nColumns; k++ ) {
+            for ( Index k = 1; k <= aMatrix.cols(); k++ ) {
                 coeff += aMatrix.at(i, k) * bMatrix.at(k, j);
             }
 
@@ -359,11 +387,11 @@ void FloatMatrix :: beTProductOf(const FloatMatrix &aMatrix, const FloatMatrix &
 // Receiver = aMatrix^T * bMatrix
 {
 #  ifndef NDEBUG
-    if ( aMatrix.nRows != bMatrix.nRows ) {
+    if ( aMatrix.rows() != bMatrix.rows() ) {
         OOFEM_ERROR("error in product A*B : dimensions do not match");
     }
 #  endif
-    _resize_internal(aMatrix.nColumns, bMatrix.nColumns);
+    _resize_internal(aMatrix.cols(), bMatrix.cols());
 #  ifdef __LAPACK_MODULE
     double alpha = 1., beta = 0.;
     dgemm_("t", "n", & this->nRows, & this->nColumns, & aMatrix.nRows,
@@ -371,10 +399,10 @@ void FloatMatrix :: beTProductOf(const FloatMatrix &aMatrix, const FloatMatrix &
            & beta, this->givePointer(), & this->nRows,
            aMatrix.nColumns, bMatrix.nColumns, this->nColumns);
 #  else
-    for ( std::size_t i = 1; i <= aMatrix.nColumns; i++ ) {
-        for (std::size_t j = 1; j <= bMatrix.nColumns; j++ ) {
+    for ( Index i = 1; i <= aMatrix.cols(); i++ ) {
+        for (Index j = 1; j <= bMatrix.cols(); j++ ) {
             double coeff = 0.;
-            for (std::size_t k = 1; k <= aMatrix.nRows; k++ ) {
+            for (Index k = 1; k <= aMatrix.rows(); k++ ) {
                 coeff += aMatrix.at(k, i) * bMatrix.at(k, j);
             }
 
@@ -389,11 +417,11 @@ void FloatMatrix :: beProductTOf(const FloatMatrix &aMatrix, const FloatMatrix &
 // Receiver = aMatrix * bMatrix^T
 {
 #  ifndef NDEBUG
-    if ( aMatrix.nColumns != bMatrix.nColumns ) {
+    if ( aMatrix.cols() != bMatrix.cols() ) {
         OOFEM_ERROR("error in product A*B : dimensions do not match");
     }
 #  endif
-    _resize_internal(aMatrix.nRows, bMatrix.nRows);
+    _resize_internal(aMatrix.rows(), bMatrix.rows());
 #  ifdef __LAPACK_MODULE
     double alpha = 1., beta = 0.;
     dgemm_("n", "t", & this->nRows, & this->nColumns, & aMatrix.nColumns,
@@ -401,10 +429,10 @@ void FloatMatrix :: beProductTOf(const FloatMatrix &aMatrix, const FloatMatrix &
            & beta, this->givePointer(), & this->nRows,
            aMatrix.nColumns, bMatrix.nColumns, this->nColumns);
 #  else
-    for (std::size_t i = 1; i <= aMatrix.nRows; i++ ) {
-        for (std::size_t j = 1; j <= bMatrix.nRows; j++ ) {
+    for (Index i = 1; i <= aMatrix.rows(); i++ ) {
+        for (Index j = 1; j <= bMatrix.rows(); j++ ) {
             double coeff = 0.;
-            for (std::size_t k = 1; k <= aMatrix.nColumns; k++ ) {
+            for (Index k = 1; k <= aMatrix.cols(); k++ ) {
                 coeff += aMatrix.at(i, k) * bMatrix.at(j, k);
             }
 
@@ -419,10 +447,10 @@ void FloatMatrix :: addProductOf(const FloatMatrix &aMatrix, const FloatMatrix &
 // Receiver = aMatrix * bMatrix
 {
 #  ifndef NDEBUG
-    if ( aMatrix.nColumns != bMatrix.nRows ) {
+    if ( aMatrix.cols() != bMatrix.rows() ) {
         OOFEM_ERROR("error in product A*B : dimensions do not match");
     }
-    if ( aMatrix.nRows != this->nRows || bMatrix.nColumns != this->nColumns ) {
+    if ( aMatrix.rows() != this->rows() || bMatrix.cols() != this->cols() ) {
         OOFEM_ERROR("error in product receiver : dimensions do not match");
     }
 #  endif
@@ -434,10 +462,10 @@ void FloatMatrix :: addProductOf(const FloatMatrix &aMatrix, const FloatMatrix &
            & beta, this->givePointer(), & this->nRows,
            aMatrix.nColumns, bMatrix.nColumns, this->nColumns);
 #  else
-    for (std::size_t i = 1; i <= aMatrix.nRows; i++ ) {
-        for (std::size_t j = 1; j <= bMatrix.nColumns; j++ ) {
+    for (Index i = 1; i <= aMatrix.rows(); i++ ) {
+        for (Index j = 1; j <= bMatrix.cols(); j++ ) {
             double coeff = 0.;
-            for (std::size_t k = 1; k <= aMatrix.nColumns; k++ ) {
+            for (Index k = 1; k <= aMatrix.cols(); k++ ) {
                 coeff += aMatrix.at(i, k) * bMatrix.at(k, j);
             }
 
@@ -451,10 +479,10 @@ void FloatMatrix :: addTProductOf(const FloatMatrix &aMatrix, const FloatMatrix 
 // Receiver += aMatrix^T * bMatrix
 {
 #  ifndef NDEBUG
-    if ( aMatrix.nRows != bMatrix.nRows ) {
+    if ( aMatrix.rows() != bMatrix.rows() ) {
         OOFEM_ERROR("error in product A*B : dimensions do not match");
     }
-    if ( aMatrix.nColumns != this->nColumns || bMatrix.nColumns != this->nRows ) {
+    if ( aMatrix.cols() != this->cols() || bMatrix.cols() != this->rows() ) {
         OOFEM_ERROR("error in product receiver : dimensions do not match");
     }
 #  endif
@@ -466,10 +494,10 @@ void FloatMatrix :: addTProductOf(const FloatMatrix &aMatrix, const FloatMatrix 
            & beta, this->givePointer(), & this->nRows,
            aMatrix.nColumns, bMatrix.nColumns, this->nColumns);
 #  else
-    for (std::size_t i = 1; i <= aMatrix.nColumns; i++ ) {
-        for (std::size_t j = 1; j <= bMatrix.nColumns; j++ ) {
+    for (Index i = 1; i <= aMatrix.cols(); i++ ) {
+        for (Index j = 1; j <= bMatrix.cols(); j++ ) {
             double coeff = 0.;
-            for (std::size_t k = 1; k <= aMatrix.nRows; k++ ) {
+            for (Index k = 1; k <= aMatrix.rows(); k++ ) {
                 coeff += aMatrix.at(k, i) * bMatrix.at(k, j);
             }
 
@@ -645,8 +673,7 @@ void FloatMatrix :: setColumn(const FloatArray &src, int c)
     }
 #endif
 
-    auto P = this->values.begin() + ( c - 1 ) * nr;
-    std :: copy(src.begin(), src.end(), P);
+    for(int r=0; r<nr; r++) (*this)(r,c-1)=src(r);
 }
 
 
@@ -660,8 +687,7 @@ void FloatMatrix :: copyColumn(FloatArray &dest, int c) const
 #endif
 
     dest.resize(nr);
-    auto P = this->values.begin() + ( c - 1 ) * nr;
-    std :: copy( P, P + nr, dest.begin() );
+    for(int r=0; r<nr; r++) dest(r)=(*this)(r,c-1);
 }
 
 
@@ -695,9 +721,7 @@ void FloatMatrix :: plusProductSymmUpper(const FloatMatrix &a, const FloatMatrix
 // not compute the transposition of matrix a.
 {
     if ( !this->isNotEmpty() ) {
-        this->nRows = a.nColumns;
-        this->nColumns = b.nColumns;
-        this->values.assign(a.nColumns * b.nColumns, 0.);
+        this->resize(a.cols(),b.cols());
     }
 
 #ifdef __LAPACK_MODULE
@@ -730,10 +754,10 @@ void FloatMatrix :: plusProductSymmUpper(const FloatMatrix &a, const FloatMatrix
         }
     }
 #else
-    for (std::size_t i = 1; i <= nRows; i++ ) {
-        for (std::size_t j = i; j <= nColumns; j++ ) {
+    for (Index i = 1; i <= rows(); i++ ) {
+        for (Index j = i; j <= cols(); j++ ) {
             double summ = 0.;
-            for (std::size_t k = 1; k <= a.nRows; k++ ) {
+            for (Index k = 1; k <= a.rows(); k++ ) {
                 summ += a.at(k, i) * b.at(k, j);
             }
 
@@ -747,9 +771,7 @@ void FloatMatrix :: plusProductSymmUpper(const FloatMatrix &a, const FloatMatrix
 void FloatMatrix :: plusDyadSymmUpper(const FloatArray &a, double dV)
 {
     if ( !this->isNotEmpty() ) {
-        this->nRows = a.giveSize();
-        this->nColumns = a.giveSize();
-        this->values.assign(this->nRows * this->nColumns, 0.);
+        this->resize(a.giveSize(),a.giveSize());
     }
 #ifdef __LAPACK_MODULE
     int inc = 1;
@@ -758,8 +780,8 @@ void FloatMatrix :: plusDyadSymmUpper(const FloatArray &a, double dV)
           this->givePointer(), & this->nRows,
           sizeA, this->nColumns);
 #else
-    for (std::size_t i = 1; i <= nRows; i++ ) {
-        for (std::size_t j = i; j <= nColumns; j++ ) {
+    for (Index i = 1; i <= rows(); i++ ) {
+        for (Index j = i; j <= cols(); j++ ) {
             this->at(i, j) += a.at(i) * a.at(j) * dV;
         }
     }
@@ -774,9 +796,7 @@ void FloatMatrix :: plusProductUnsym(const FloatMatrix &a, const FloatMatrix &b,
 // Advantage : does not compute the transposition of matrix a.
 {
     if ( !this->isNotEmpty() ) {
-        this->nRows = a.nColumns;
-        this->nColumns = b.nColumns;
-        this->values.assign(this->nRows * this->nColumns, 0.);
+        this->resize(a.cols(),b.cols());
     }
 #ifdef __LAPACK_MODULE
     double beta = 1.;
@@ -785,10 +805,10 @@ void FloatMatrix :: plusProductUnsym(const FloatMatrix &a, const FloatMatrix &b,
            & beta, this->givePointer(), & this->nRows,
            a.nColumns, b.nColumns, this->nColumns);
 #else
-    for (std::size_t i = 1; i <= nRows; i++ ) {
-        for (std::size_t j = 1; j <= nColumns; j++ ) {
+    for (Index i = 1; i <= rows(); i++ ) {
+        for (Index j = 1; j <= cols(); j++ ) {
             double summ = 0.;
-            for (std::size_t k = 1; k <= a.nRows; k++ ) {
+            for (Index k = 1; k <= a.rows(); k++ ) {
                 summ += a.at(k, i) * b.at(k, j);
             }
 
@@ -802,9 +822,7 @@ void FloatMatrix :: plusProductUnsym(const FloatMatrix &a, const FloatMatrix &b,
 void FloatMatrix :: plusDyadUnsym(const FloatArray &a, const FloatArray &b, double dV)
 {
     if ( !this->isNotEmpty() ) {
-        this->nRows = a.giveSize();
-        this->nColumns = b.giveSize();
-        this->values.assign(this->nRows * this->nColumns, 0.);
+        this->resize(a.giveSize(),b.giveSize());
     }
 #ifdef __LAPACK_MODULE
     int inc = 1;
@@ -814,8 +832,8 @@ void FloatMatrix :: plusDyadUnsym(const FloatArray &a, const FloatArray &b, doub
           b.givePointer(), & inc, this->givePointer(), & this->nRows,
           sizeA, sizeB, this->nColumns);
 #else
-    for (std::size_t i = 1; i <= nRows; i++ ) {
-        for (std::size_t j = 1; j <= nColumns; j++ ) {
+    for (Index i = 1; i <= rows(); i++ ) {
+        for (Index j = 1; j <= cols(); j++ ) {
             this->at(i, j) += a.at(i) * b.at(j) * dV;
         }
     }
@@ -830,11 +848,12 @@ bool FloatMatrix :: beInverseOf(const FloatMatrix &src)
 
 #  ifndef NDEBUG
     if ( !src.isSquare() ) {
-        OOFEM_ERROR("cannot inverse a %d by %d matrix", src.nRows, src.nColumns);
+        OOFEM_ERROR("cannot inverse a %d by %d matrix", src.rows(), src.cols());
     }
 #  endif
 
-    _resize_internal(src.nRows, src.nColumns);
+    _resize_internal(src.rows(), src.cols());
+    int nRows=this->rows();
 
     if ( nRows == 1 ) {
         if (fabs(src.at(1,1)) > 1.e-30) {
@@ -903,40 +922,40 @@ bool FloatMatrix :: beInverseOf(const FloatMatrix &src)
         FloatMatrix tmp = src;
         // initialize answer to be unity matrix;
         this->zero();
-        for (std::size_t i = 1; i <= nRows; i++ ) {
+        for (Index i = 1; i <= nRows; i++ ) {
             this->at(i, i) = 1.0;
         }
 
         // lower triangle elimination by columns
-        for (std::size_t i = 1; i < nRows; i++ ) {
+        for (Index i = 1; i < nRows; i++ ) {
             piv = tmp.at(i, i);
             if ( fabs(piv) < 1.e-30 ) {
                 OOFEM_WARNING("pivot (%d,%d) to close to small (< 1.e-20)", i, i);
                 return false;
             }
 
-            for (std::size_t j = i + 1; j <= nRows; j++ ) {
+            for (Index j = i + 1; j <= nRows; j++ ) {
                 linkomb = tmp.at(j, i) / tmp.at(i, i);
-                for (std::size_t k = i; k <= nRows; k++ ) {
+                for (Index k = i; k <= nRows; k++ ) {
                     tmp.at(j, k) -= tmp.at(i, k) * linkomb;
                 }
 
-                for (std::size_t k = 1; k <= nRows; k++ ) {
+                for (Index k = 1; k <= nRows; k++ ) {
                     this->at(j, k) -= this->at(i, k) * linkomb;
                 }
             }
         }
 
         // upper triangle elimination by columns
-        for ( std::size_t i = nRows; i > 1; i-- ) {
+        for ( Index i = nRows; i > 1; i-- ) {
             piv = tmp.at(i, i);
-            for ( std::size_t j = i - 1; j > 0; j-- ) {
+            for ( Index j = i - 1; j > 0; j-- ) {
                 linkomb = tmp.at(j, i) / piv;
-                for ( std::size_t k = i; k > 0; k-- ) {
+                for ( Index k = i; k > 0; k-- ) {
                     tmp.at(j, k) -= tmp.at(i, k) * linkomb;
                 }
 
-                for ( std::size_t k = nRows; k > 0; k-- ) {
+                for ( Index k = nRows; k > 0; k-- ) {
                     // tmp -> at(j,k)-= tmp  ->at(i,k)*linkomb;
                     this->at(j, k) -= this->at(i, k) * linkomb;
                 }
@@ -944,8 +963,8 @@ bool FloatMatrix :: beInverseOf(const FloatMatrix &src)
         }
 
         // diagonal scaling
-        for ( std::size_t i = 1; i <= nRows; i++ ) {
-            for ( std::size_t j = 1; j <= nRows; j++ ) {
+        for ( Index i = 1; i <= nRows; i++ ) {
+            for ( Index j = 1; j <= nRows; j++ ) {
                 this->at(i, j) /= tmp.at(i, i);
             }
         }
@@ -956,7 +975,7 @@ bool FloatMatrix :: beInverseOf(const FloatMatrix &src)
 
 
 void FloatMatrix :: beSubMatrixOf(const FloatMatrix &src,
-                                  std::size_t topRow, std::size_t bottomRow, std::size_t topCol, std::size_t bottomCol)
+                                  Index topRow, Index bottomRow, Index topCol, Index bottomCol)
 /*
  * modifies receiver to be  submatrix of the src matrix
  * size of receiver  submatrix is determined from
@@ -968,21 +987,21 @@ void FloatMatrix :: beSubMatrixOf(const FloatMatrix &src,
         OOFEM_ERROR("subindexes size mismatch");
     }
 
-    if ( ( src.nRows < bottomRow ) || ( src.nColumns < bottomCol ) || ( ( bottomRow - topRow ) > src.nRows ) ||
-         ( ( bottomCol - topCol ) > src.nColumns ) ) {
+    if ( ( src.rows() < bottomRow ) || ( src.cols() < bottomCol ) || ( ( bottomRow - topRow ) > src.rows() ) ||
+         ( ( bottomCol - topCol ) > src.cols() ) ) {
         OOFEM_ERROR("subindexes size mismatch");
     }
 #endif
 
 
-    std::size_t topRm1, topCm1;
+    Index topRm1, topCm1;
     topRm1 = topRow - 1;
     topCm1 = topCol - 1;
 
     // allocate return value
     this->resize(bottomRow - topRm1, bottomCol - topCm1);
-    for (std::size_t i = topRow; i <= bottomRow; i++ ) {
-        for (std::size_t j = topCol; j <= bottomCol; j++ ) {
+    for (Index i = topRow; i <= bottomRow; i++ ) {
+        for (Index j = topCol; j <= bottomCol; j++ ) {
             this->at(i - topRm1, j - topCm1) = src.at(i, j);
         }
     }
@@ -1020,7 +1039,7 @@ void FloatMatrix :: add(const FloatMatrix &aMatrix)
 // Adds aMatrix to the receiver. If the receiver has a null size,
 // adjusts its size to that of aMatrix. Returns the modified receiver.
 {
-    if ( aMatrix.nRows == 0 || aMatrix.nColumns == 0 ) {
+    if ( aMatrix.rows() == 0 || aMatrix.cols() == 0 ) {
         return;
     }
 
@@ -1029,8 +1048,8 @@ void FloatMatrix :: add(const FloatMatrix &aMatrix)
         return;
     }
 #     ifndef NDEBUG
-    if ( ( aMatrix.nRows != nRows || aMatrix.nColumns != nColumns ) && aMatrix.isNotEmpty() ) {
-        OOFEM_ERROR("dimensions mismatch : (r1,c1)+(r2,c2) : (%d,%d)+(%d,%d)", nRows, nColumns, aMatrix.nRows, aMatrix.nColumns);
+    if ( ( aMatrix.rows() != rows() || aMatrix.cols() != cols() ) && aMatrix.isNotEmpty() ) {
+        OOFEM_ERROR("dimensions mismatch : (r1,c1)+(r2,c2) : (%d,%d)+(%d,%d)", rows(), cols(), aMatrix.rows(), aMatrix.cols());
     }
 #     endif
 
@@ -1040,9 +1059,7 @@ void FloatMatrix :: add(const FloatMatrix &aMatrix)
     double s = 1.;
     daxpy_(& aSize, & s, aMatrix.givePointer(), & inc, this->givePointer(), & inc, aSize, aSize);
 #else
-    for ( size_t i = 0; i < this->values.size(); i++ ) {
-        this->values [ i ] += aMatrix.values [ i ];
-    }
+    _LOOP_MATRIX(r,c){ (*this)(r,c)+=aMatrix(r,c); }
 #endif
 }
 
@@ -1051,7 +1068,7 @@ void FloatMatrix :: add(double s, const FloatMatrix &aMatrix)
 // Adds aMatrix to the receiver. If the receiver has a null size,
 // adjusts its size to that of aMatrix. Returns the modified receiver.
 {
-    if ( aMatrix.nRows == 0 || aMatrix.nColumns == 0 ) {
+    if ( aMatrix.rows() == 0 || aMatrix.cols() == 0 ) {
         return;
     }
 
@@ -1061,8 +1078,8 @@ void FloatMatrix :: add(double s, const FloatMatrix &aMatrix)
         return;
     }
 #     ifndef NDEBUG
-    if ( ( aMatrix.nRows != nRows || aMatrix.nColumns != nColumns ) && aMatrix.isNotEmpty() ) {
-        OOFEM_ERROR("dimensions mismatch : (r1,c1)+(r2,c2) : (%d,%d)+(%d,%d)", nRows, nColumns, aMatrix.nRows, aMatrix.nColumns);
+    if ( ( aMatrix.rows() != rows() || aMatrix.cols() != cols() ) && aMatrix.isNotEmpty() ) {
+        OOFEM_ERROR("dimensions mismatch : (r1,c1)+(r2,c2) : (%d,%d)+(%d,%d)", rows(), cols(), aMatrix.rows(), aMatrix.cols());
     }
 #     endif
 
@@ -1071,9 +1088,7 @@ void FloatMatrix :: add(double s, const FloatMatrix &aMatrix)
     int inc = 1;
     daxpy_(& aSize, & s, aMatrix.givePointer(), & inc, this->givePointer(), & inc, aSize, aSize);
 #else
-    for ( size_t i = 0; i < this->values.size(); i++ ) {
-        this->values [ i ] += s * aMatrix.values [ i ];
-    }
+    _LOOP_MATRIX(r,c){ (*this)(r,c)+=s*aMatrix(r,c); }
 #endif
 }
 
@@ -1087,8 +1102,8 @@ void FloatMatrix :: subtract(const FloatMatrix &aMatrix)
         return;
     }
 #     ifndef NDEBUG
-    if ( ( aMatrix.nRows != nRows || aMatrix.nColumns != nColumns ) && aMatrix.isNotEmpty() ) {
-        OOFEM_ERROR("dimensions mismatch : (r1,c1)-(r2,c2) : (%d,%d)-(%d,%d)", nRows, nColumns, aMatrix.nRows, aMatrix.nColumns);
+    if ( ( aMatrix.rows() != rows() || aMatrix.cols() != cols() ) && aMatrix.isNotEmpty() ) {
+        OOFEM_ERROR("dimensions mismatch : (r1,c1)-(r2,c2) : (%d,%d)-(%d,%d)", rows(), cols(), aMatrix.rows(), aMatrix.cols());
     }
 #     endif
 
@@ -1098,9 +1113,7 @@ void FloatMatrix :: subtract(const FloatMatrix &aMatrix)
     double s = -1.;
     daxpy_(& aSize, & s, aMatrix.givePointer(), & inc, this->givePointer(), & inc, aSize, aSize);
 #else
-    for ( size_t i = 0; i < this->values.size(); i++ ) {
-        this->values [ i ] -= aMatrix.values [ i ];
-    }
+    _LOOP_MATRIX(r,c){ (*this)(r,c)-=aMatrix(r,c); }
 #endif
 }
 
@@ -1110,10 +1123,10 @@ bool FloatMatrix :: solveForRhs(const FloatArray &b, FloatArray &answer, bool tr
 {
 #  ifndef NDEBUG
     if ( !this->isSquare() ) {
-        OOFEM_ERROR("cannot solve a %d by %d matrix", nRows, nColumns);
+        OOFEM_ERROR("cannot solve a %d by %d matrix", rows(), cols());
     }
 
-    if ( nRows != b.size() ) {
+    if ( rows() != b.size() ) {
         OOFEM_ERROR("dimension mismatch");
     }
 #  endif
@@ -1131,7 +1144,7 @@ bool FloatMatrix :: solveForRhs(const FloatArray &b, FloatArray &answer, bool tr
         return false;
     }
 #else
-    std::size_t pivRow;
+    Index pivRow;
     double piv, linkomb, help;
     FloatMatrix *mtrx, trans;
     if ( transpose ) {
@@ -1145,11 +1158,12 @@ bool FloatMatrix :: solveForRhs(const FloatArray &b, FloatArray &answer, bool tr
 
     // initialize answer to be unity matrix;
     // lower triangle elimination by columns
-    for ( std::size_t i = 1; i < nRows; i++ ) {
+    int nRows=this->rows();
+    for ( Index i = 1; i < nRows; i++ ) {
         // find the suitable row and pivot
         piv = fabs( mtrx->at(i, i) );
         pivRow = i;
-        for (std::size_t j = i + 1; j <= nRows; j++ ) {
+        for (Index j = i + 1; j <= nRows; j++ ) {
             if ( fabs( mtrx->at(j, i) ) > piv ) {
                 pivRow = j;
                 piv = fabs( mtrx->at(j, i) );
@@ -1162,7 +1176,7 @@ bool FloatMatrix :: solveForRhs(const FloatArray &b, FloatArray &answer, bool tr
 
         // exchange rows
         if ( pivRow != i ) {
-            for (std::size_t j = i; j <= nRows; j++ ) {
+            for (Index j = i; j <= nRows; j++ ) {
                 help = mtrx->at(i, j);
                 mtrx->at(i, j) = mtrx->at(pivRow, j);
                 mtrx->at(pivRow, j) = help;
@@ -1172,9 +1186,9 @@ bool FloatMatrix :: solveForRhs(const FloatArray &b, FloatArray &answer, bool tr
             answer.at(pivRow) = help;
         }
 
-        for (std::size_t j = i + 1; j <= nRows; j++ ) {
+        for (Index j = i + 1; j <= nRows; j++ ) {
             linkomb = mtrx->at(j, i) / mtrx->at(i, i);
-            for (std::size_t k = i; k <= nRows; k++ ) {
+            for (Index k = i; k <= nRows; k++ ) {
                 mtrx->at(j, k) -= mtrx->at(i, k) * linkomb;
             }
 
@@ -1183,9 +1197,9 @@ bool FloatMatrix :: solveForRhs(const FloatArray &b, FloatArray &answer, bool tr
     }
 
     // back substitution
-    for ( std::size_t i = nRows; i >= 1; i-- ) {
+    for ( Index i = nRows; i >= 1; i-- ) {
         help = 0.;
-        for ( std::size_t j = i + 1; j <= nRows; j++ ) {
+        for ( Index j = i + 1; j <= nRows; j++ ) {
             help += mtrx->at(i, j) * answer.at(j);
         }
 
@@ -1206,10 +1220,10 @@ bool FloatMatrix :: solveForRhs(const FloatMatrix &b, FloatMatrix &answer, bool 
 {
 #  ifndef NDEBUG
     if ( !this->isSquare() ) {
-        OOFEM_ERROR("cannot solve a %d by %d matrix", nRows, nColumns);
+        OOFEM_ERROR("cannot solve a %d by %d matrix", rows(), cols());
     }
 
-    if ( nRows != b.giveRowSize() ) {
+    if ( rows() != b.rows() ) {
         OOFEM_ERROR("dimension mismatch");
     }
 #  endif
@@ -1226,7 +1240,7 @@ bool FloatMatrix :: solveForRhs(const FloatMatrix &b, FloatMatrix &answer, bool 
         return false; //OOFEM_ERROR("error %d", info);
     }
 #else
-    std::size_t pivRow, nPs;
+    Index pivRow, nPs;
     double piv, linkomb, help;
     FloatMatrix *mtrx, trans;
     if ( transpose ) {
@@ -1238,13 +1252,14 @@ bool FloatMatrix :: solveForRhs(const FloatMatrix &b, FloatMatrix &answer, bool 
 
     nPs = b.giveNumberOfColumns();
     answer = b;
+    int nRows=this->rows();
     // initialize answer to be unity matrix;
     // lower triangle elimination by columns
-    for (std::size_t i = 1; i < nRows; i++ ) {
+    for (Index i = 1; i < nRows; i++ ) {
         // find the suitable row and pivot
         piv = fabs( mtrx->at(i, i) );
         pivRow = i;
-        for (std::size_t j = i + 1; j <= nRows; j++ ) {
+        for (Index j = i + 1; j <= nRows; j++ ) {
             if ( fabs( mtrx->at(j, i) ) > piv ) {
                 pivRow = j;
                 piv = fabs( mtrx->at(j, i) );
@@ -1257,36 +1272,36 @@ bool FloatMatrix :: solveForRhs(const FloatMatrix &b, FloatMatrix &answer, bool 
 
         // exchange rows
         if ( pivRow != i ) {
-            for (std::size_t j = i; j <= nRows; j++ ) {
+            for (Index j = i; j <= nRows; j++ ) {
                 help = mtrx->at(i, j);
                 mtrx->at(i, j) = mtrx->at(pivRow, j);
                 mtrx->at(pivRow, j) = help;
             }
 
-            for (std::size_t j = 1; j <= nPs; j++ ) {
+            for (Index j = 1; j <= nPs; j++ ) {
                 help = answer.at(i, j);
                 answer.at(i, j) = answer.at(pivRow, j);
                 answer.at(pivRow, j) = help;
             }
         }
 
-        for (std::size_t j = i + 1; j <= nRows; j++ ) {
+        for (Index j = i + 1; j <= nRows; j++ ) {
             linkomb = mtrx->at(j, i) / mtrx->at(i, i);
-            for (std::size_t k = i; k <= nRows; k++ ) {
+            for (Index k = i; k <= nRows; k++ ) {
                 mtrx->at(j, k) -= mtrx->at(i, k) * linkomb;
             }
 
-            for (std::size_t k = 1; k <= nPs; k++ ) {
+            for (Index k = 1; k <= nPs; k++ ) {
                 answer.at(j, k) -= answer.at(i, k) * linkomb;
             }
         }
     }
 
     // back substitution
-    for ( std::size_t i = nRows; i >= 1; i-- ) {
-        for (std::size_t k = 1; k <= nPs; k++ ) {
+    for ( Index i = nRows; i >= 1; i-- ) {
+        for (Index k = 1; k <= nPs; k++ ) {
             help = 0.;
-            for ( std::size_t j = i + 1; j <= nRows; j++ ) {
+            for ( Index j = i + 1; j <= nRows; j++ ) {
                 help += mtrx->at(i, j) * answer.at(j, k);
             }
 
@@ -1305,20 +1320,18 @@ void FloatMatrix :: initFromVector(const FloatArray &vector, bool transposed)
 //
 {
     if ( transposed ) {
-        this->nRows = 1;
-        this->nColumns = vector.giveSize();
+        this->resize(1,vector.size());
+        for(int c=0; c<cols(); c++) (*this)(0,c)=vector(c);
     } else {
-        this->nRows = vector.giveSize();
-        this->nColumns = 1;
+        this->resize(vector.size(),1);
+        for(int r=0; r<rows(); r++) (*this)(r,0)=vector(r);
     }
-
-    this->values = vector.values;
 }
 
 
 void FloatMatrix :: zero()
 {
-    std :: fill(this->values.begin(), this->values.end(), 0.);
+    _LOOP_MATRIX(r,c) (*this)(r,c)=0.;
 }
 
 
@@ -1326,12 +1339,12 @@ void FloatMatrix :: beUnitMatrix()
 {
 #ifndef NDEBUG
     if ( !this->isSquare() ) {
-        OOFEM_ERROR("cannot make unit matrix of %d by %d matrix", nRows, nColumns);
+        OOFEM_ERROR("cannot make unit matrix of %d by %d matrix", rows(), cols());
     }
 #endif
 
     this->zero();
-    for (std::size_t i = 1; i <= nRows; i++ ) {
+    for (Index i = 1; i <= rows(); i++ ) {
         this->at(i, i) = 1.0;
     }
 }
@@ -1341,48 +1354,11 @@ void FloatMatrix :: bePinvID()
 // this matrix is the product of the 6x6 deviatoric projection matrix ID
 // and the inverse scaling matrix Pinv
 {
-    this->resize(6, 6);
-    values [ 0 ] = values [ 7 ] = values [ 14 ] = 2. / 3.;
-    values [ 1 ] = values [ 2 ] = values [ 6 ] = values [ 8 ] = values [ 12 ] = values [ 13 ] = -1. / 3.;
-    values [ 21 ] = values [ 28 ] = values [ 35 ] = 0.5;
-}
-
-
-void FloatMatrix :: resize(std::size_t rows, std::size_t columns)
-//
-// resizes receiver, all data will be lost
-//
-{
-    this->nRows = rows;
-    this->nColumns = columns;
-    this->values.assign(rows * columns, 0.);
-}
-
-
-void FloatMatrix :: resizeWithData(std::size_t rows, std::size_t columns)
-//
-// resizes receiver, all data kept
-//
-{
-    // Check of resize if necessary at all.
-    if ( rows == this->nRows && columns == this->nColumns ) {
-        return;
-    }
-
-    FloatMatrix old( std :: move(* this) );
-
-    this->nRows = rows;
-    this->nColumns = columns;
-    this->values.resize(rows * columns);
-
-    std::size_t ii = min( rows, old.giveRowSize() );
-    std::size_t jj = min( columns, old.giveColSize() );
-    // copy old values if possible
-    for (std::size_t i = 1; i <= ii; i++ ) {
-        for (std::size_t j = 1; j <= jj; j++ ) {
-            this->at(i, j) = old.at(i, j);
-        }
-    }
+    FloatMatrix& m(*this);
+    m.resize(6, 6);
+    m(0,0)=m(1,1)=m(2,2)=2/3.;
+    m(0,1)=m(0,2)=m(1,0)=m(2,0)=m(1,2)=m(2,1)=-1/3.;
+    m(3,3)=m(4,4)=m(5,5)=1/2.;
 }
 
 
@@ -1392,22 +1368,23 @@ double FloatMatrix :: giveDeterminant() const
 {
 #  ifndef NDEBUG
     if ( !this->isSquare() ) {
-        OOFEM_ERROR("cannot compute the determinant of a non-square %d by %d matrix", nRows, nColumns);
+        OOFEM_ERROR("cannot compute the determinant of a non-square %d by %d matrix", rows(), cols());
     }
 #  endif
-
-    if ( nRows == 1 ) {
-        return values [ 0 ];
-    } else if ( nRows == 2 ) {
-        return ( values [ 0 ] * values [ 3 ] - values [ 1 ] * values [ 2 ] );
-    } else if ( nRows == 3 ) {
-        return ( values [ 0 ] * values [ 4 ] * values [ 8 ] + values [ 3 ] * values [ 7 ] * values [ 2 ] +
-                 values [ 6 ] * values [ 1 ] * values [ 5 ] - values [ 6 ] * values [ 4 ] * values [ 2 ] -
-                 values [ 7 ] * values [ 5 ] * values [ 0 ] - values [ 8 ] * values [ 3 ] * values [ 1 ] );
-    } else {
-        OOFEM_ERROR("sorry, cannot compute the determinant of a matrix larger than 3x3");
+    const FloatMatrix& m(*this);
+    if ( rows() == 1 ) {
+        return m(0,0);
+    } else if ( rows() == 2 ) {
+        // return ( values [ 0 ] * values [ 3 ] - values [ 1 ] * values [ 2 ] );
+        return m(0,0)*m(1,1)-m(1,0)*m(0,1);
+        // return ( values [ 0 ] * values [ 3 ] - values [ 1 ] * values [ 2 ] );
+    } else if ( rows() == 3 ) {
+        return
+             m(0,0)*m(1,1)*m(2,2)+m(1,0)*m(2,1)*m(0,2)+m(2,0)*m(0,1)*m(1,2)
+            -m(0,2)*m(1,1)*m(2,0)-m(1,2)*m(2,1)*m(0,0)-m(2,2)*m(0,1)*m(1,0);
     }
 
+    OOFEM_ERROR("sorry, cannot compute the determinant of a matrix larger than 3x3");
     // return 0.;
 }
 
@@ -1426,12 +1403,12 @@ double FloatMatrix :: giveTrace() const
 {
 #  ifndef NDEBUG
     if ( !this->isSquare() ) {
-        OOFEM_ERROR("cannot compute the trace of a non-square %d by %d matrix", nRows, nColumns);
+        OOFEM_ERROR("cannot compute the trace of a non-square %d by %d matrix", rows(), cols());
     }
 #  endif
     double answer = 0.;
-    for (std::size_t k = 0; k < nRows; k++ ) {
-        answer += values [ k * ( nRows + 1 ) ];
+    for (Index k = 0; k < rows(); k++ ) {
+        answer += (*this)(k,k);;
     }
     return answer;
 }
@@ -1440,11 +1417,11 @@ double FloatMatrix :: giveTrace() const
 void FloatMatrix :: printYourself() const
 // Prints the receiver on screen.
 {
-    printf("FloatMatrix with dimensions : %zu %zu\n",
-           nRows, nColumns);
-    if ( nRows <= 250 && nColumns <= 250 ) {
-        for (std::size_t i = 1; i <= nRows; ++i ) {
-            for (std::size_t j = 1; j <= nColumns && j <= 100; ++j ) {
+    printf("FloatMatrix with dimensions : %d %d\n",
+           rows(), cols());
+    if ( rows() <= 250 && cols() <= 250 ) {
+        for (Index i = 1; i <= rows(); ++i ) {
+            for (Index j = 1; j <= cols() && j <= 100; ++j ) {
                 printf( "%10.3e  ", this->at(i, j) );
             }
 
@@ -1462,10 +1439,10 @@ void FloatMatrix :: printYourselfToFile(const std::string filename, const bool s
     std :: ofstream matrixfile (filename);
     if (matrixfile.is_open()) {
         if (showDimensions)
-            matrixfile << "FloatMatrix with dimensions : " << nRows << ", " << nColumns << "\n";
+            matrixfile << "FloatMatrix with dimensions : " << rows() << ", " << cols() << "\n";
         matrixfile << std::scientific << std::right << std::setprecision(3);
-        for (std::size_t i = 1; i <= nRows; ++i ) {
-            for (std::size_t j = 1; j <= nColumns; ++j ) {
+        for (Index i = 1; i <= rows(); ++i ) {
+            for (Index j = 1; j <= cols(); ++j ) {
                 matrixfile << std::setw(10) << this->at(i, j) << "\t";
             }
 
@@ -1481,24 +1458,24 @@ void FloatMatrix :: printYourselfToFile(const std::string filename, const bool s
 void FloatMatrix :: printYourself(const std::string &name) const
 // Prints the receiver on screen.
 {
-    printf("%s (%zu x %zu): \n", name.c_str(), nRows, nColumns);
-    if ( nRows <= 250 && nColumns <= 250 ) {
-        for (std::size_t i = 1; i <= nRows; ++i ) {
-            for (std::size_t j = 1; j <= nColumns && j <= 100; ++j ) {
+    printf("%s (%d x %d): \n", name.c_str(), rows(), cols());
+    if ( rows() <= 250 && cols() <= 250 ) {
+        for (Index i = 1; i <= rows(); ++i ) {
+            for (Index j = 1; j <= cols() && j <= 100; ++j ) {
                 printf( "%10.3e  ", this->at(i, j) );
             }
 
             printf("\n");
         }
     } else {
-        for (std::size_t i = 1; i <= nRows && i <= 20; ++i ) {
-            for (std::size_t j = 1; j <= nColumns && j <= 10; ++j ) {
+        for (Index i = 1; i <= rows() && i <= 20; ++i ) {
+            for (Index j = 1; j <= cols() && j <= 10; ++j ) {
                 printf( "%10.3e  ", this->at(i, j) );
             }
-            if ( nColumns > 10 ) printf(" ...");
+            if ( cols() > 10 ) printf(" ...");
             printf("\n");
         }
-        if ( nRows > 20 )  printf(" ...\n");
+        if ( rows() > 20 )  printf(" ...\n");
     }
 }
 
@@ -1507,10 +1484,10 @@ void FloatMatrix :: pY() const
 // Prints the receiver on screen with higher accuracy than printYourself.
 {
     printf("[");
-    for (std::size_t i = 1; i <= nRows; ++i ) {
-        for (std::size_t j = 1; j <= nColumns; ++j ) {
+    for (Index i = 1; i <= rows(); ++i ) {
+        for (Index j = 1; j <= cols(); ++j ) {
             printf( "%20.15e", this->at(i, j) );
-            if ( j < nColumns ) {
+            if ( j < cols() ) {
                 printf(",");
             } else {
                 printf(";");
@@ -1525,8 +1502,8 @@ void FloatMatrix :: pY() const
 void FloatMatrix :: writeCSV(const std :: string &name) const
 {
     FILE *file = fopen(name.c_str(), "w");
-    for (std::size_t i = 1; i <= nRows; ++i ) {
-        for (std::size_t j = 1; j <= nColumns; ++j ) {
+    for (Index i = 1; i <= rows(); ++i ) {
+        for (Index j = 1; j <= cols(); ++j ) {
             fprintf(file, "%10.3e, ", this->at(i, j) );
         }
 
@@ -1559,14 +1536,14 @@ void FloatMatrix :: symmetrized()
 // Initializes the lower half of the receiver to the upper half.
 {
 #  ifndef NDEBUG
-    if ( nRows != nColumns ) {
+    if ( rows() != cols() ) {
         OOFEM_ERROR("cannot symmetrize a non-square matrix");
     }
 
 #   endif
 
-    for (std::size_t i = 2; i <= nRows; i++ ) {
-        for (std::size_t j = 1; j < i; j++ ) {
+    for (Index i = 2; i <= rows(); i++ ) {
+        for (Index j = 1; j < i; j++ ) {
             this->at(i, j) = this->at(j, i);
         }
     }
@@ -1577,24 +1554,23 @@ void FloatMatrix :: times(double factor)
 // Multiplies every coefficient of the receiver by factor. Answers the
 // modified receiver.
 {
-    for ( double &x : this->values ) {
-        x *= factor;
-    }
+    _LOOP_MATRIX(r,c) (*this)(r,c)*=factor;
     // dscal_ seemed to be slower for typical usage of this function.
 }
 
 
 void FloatMatrix :: negated()
 {
-    for ( double &x : this->values ) {
-        x = -x;
-    }
+    _LOOP_MATRIX(r,c) (*this)(r,c)=-(*this)(r,c);
 }
 
 
 double FloatMatrix :: computeFrobeniusNorm() const
 {
-    return sqrt( std :: inner_product(this->values.begin(), this->values.end(), this->values.begin(), 0.) );
+    // return sqrt( std :: inner_product(this->values.begin(), this->values.end(), this->values.begin(), 0.) );
+    double ret=0;
+    _LOOP_MATRIX(r,c) ret+=(*this)(r,c)*(*this)(r,c);
+    return std::sqrt(ret);
 }
 
 double FloatMatrix :: computeNorm(char p) const
@@ -1608,9 +1584,9 @@ double FloatMatrix :: computeNorm(char p) const
 #  else
     if ( p == '1' ) { // Maximum absolute column sum.
         double col_sum, max_col = 0.0;
-        for (std::size_t j = 1; j <= this->nColumns; j++ ) {
+        for (Index j = 1; j <= this->cols(); j++ ) {
             col_sum  = 0.0;
-            for (std::size_t i = 1; i <= this->nRows; i++ ) {
+            for (Index i = 1; i <= this->rows(); i++ ) {
                 col_sum += fabs( this->at(i, j) );
             }
             if ( col_sum > max_col ) {
@@ -1674,12 +1650,12 @@ void FloatMatrix :: changeComponentOrder()
 {
     // Changes index order between abaqus <-> OOFEM
 //#  ifndef NDEBUG
-//    if ( nRows != 6 || nColumns != 6 ) {
+//    if ( nRows != 6 || cols() != 6 ) {
 //        OOFEM_ERROR("matrix dimension is not 6x6");
 //    }
 //#  endif
 
-    if ( nRows == 6 && nColumns == 6 ) {
+    if ( rows() == 6 && cols() == 6 ) {
         // This could probably be done more beautifully + efficiently.
 
         std :: swap( this->at(4, 1), this->at(6, 1) );
@@ -1696,7 +1672,7 @@ void FloatMatrix :: changeComponentOrder()
         std :: swap( this->at(6, 4), this->at(4, 6) );
 
         std :: swap( this->at(4, 5), this->at(6, 5) );
-    } else if ( nRows == 9 && nColumns == 9 ) {
+    } else if ( rows() == 9 && cols() == 9 ) {
         // OOFEM:           11, 22, 33, 23, 13, 12, 32, 31, 21
         // UMAT:            11, 22, 33, 12, 13, 23, 32, 21, 31
         const int abq2oo [ 9 ] = {
@@ -1720,7 +1696,7 @@ double FloatMatrix :: computeReciprocalCondition(char p) const
 {
 #  ifndef NDEBUG
     if ( !this->isSquare() ) {
-        OOFEM_ERROR("receiver must be square (is %d by %d)", this->nRows, this->nColumns);
+        OOFEM_ERROR("receiver must be square (is %d by %d)", this->rows(), this->cols());
     }
 #  endif
     double anorm = this->computeNorm(p);
@@ -1838,16 +1814,16 @@ contextIOResultType FloatMatrix :: storeYourself(DataStream &stream) const
 //              =0 file i/o error
 {
     // write size
-    if ( !stream.write(nRows) ) {
+    if ( !stream.write(rows()) ) {
         return ( CIO_IOERR );
     }
 
-    if ( !stream.write(nColumns) ) {
+    if ( !stream.write(cols()) ) {
         return ( CIO_IOERR );
     }
 
     // write raw data
-    if ( !stream.write(this->givePointer(), nRows * nColumns) ) {
+    if ( !stream.write(this->givePointer(), rows() * cols()) ) {
         return ( CIO_IOERR );
     }
 
@@ -1862,19 +1838,20 @@ contextIOResultType FloatMatrix :: restoreYourself(DataStream &stream)
 // returns 0 if file i/o error
 //        -1 if id of class id is not correct
 {
+    int r,c;
     // read size
-    if ( !stream.read(nRows) ) {
+    if ( !stream.read(r) ) {
         return ( CIO_IOERR );
     }
 
-    if ( !stream.read(nColumns) ) {
+    if ( !stream.read(c) ) {
         return ( CIO_IOERR );
     }
 
-    this->values.resize(nRows * nColumns);
+    this->resize(r,c); // FIXME: uselessly fills with zeros
 
     // read raw data
-    if ( !stream.read(this->givePointer(), nRows * nColumns) ) {
+    if ( !stream.read(this->givePointer(), r*c) ) {
         return ( CIO_IOERR );
     }
 
@@ -1887,7 +1864,7 @@ int
 FloatMatrix :: givePackSize(DataStream &buff) const
 {
     return buff.givePackSizeOfSizet(1) + buff.givePackSizeOfSizet(1) +
-           buff.givePackSizeOfDouble(nRows * nColumns);
+           buff.givePackSizeOfDouble(rows() * cols());
 }
 
 
@@ -2062,25 +2039,11 @@ bool FloatMatrix :: jaco_(FloatArray &eval, FloatMatrix &v, int nf)
 } /* jaco_ */
 
 
-#ifdef _BOOSTPYTHON_BINDINGS
-void
-FloatMatrix :: __setitem__(boost :: python :: api :: object t, double val)
-{
-    this->at(boost :: python :: extract< int >(t [ 0 ]) + 1, boost :: python :: extract< int >(t [ 1 ]) + 1) = val;
-}
-
-double
-FloatMatrix :: __getitem__(boost :: python :: api :: object t)
-{
-    return this->at(boost :: python :: extract< int >(t [ 0 ]) + 1, boost :: python :: extract< int >(t [ 1 ]) + 1);
-}
-#endif
-
 std :: ostream &operator << ( std :: ostream & out, const FloatMatrix & x )
 {
-    out << x.nRows << " " << x.nColumns << " {";
-    for (std::size_t i = 0; i < x.nRows; ++i ) {
-        for (std::size_t j = 0; j < x.nColumns; ++j ) {
+    out << x.rows() << " " << x.cols() << " {";
+    for (FloatMatrix::Index i = 0; i < x.rows(); ++i ) {
+        for (FloatMatrix::Index j = 0; j < x.cols(); ++j ) {
             out << " " << x(i, j);
         }
         out << ";";
@@ -2096,9 +2059,6 @@ FloatMatrix operator +( const FloatMatrix & a, const FloatMatrix & b ) {FloatMat
 FloatMatrix operator -( const FloatMatrix & a, const FloatMatrix & b ) {FloatMatrix ans(a); ans.subtract(b); return ans;}
 FloatMatrix &operator += ( FloatMatrix & a, const FloatMatrix & b ) {a.add(b); return a;}
 FloatMatrix &operator -= ( FloatMatrix & a, const FloatMatrix & b ) {a.subtract(b); return a;}
-
-
-
 
 
 

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -602,18 +602,20 @@ public:
 
 }; // class FloatMatrix
 
-//@name operators
-//@{
-/// Vector multiplication by scalar
-OOFEM_EXPORT FloatMatrix &operator *= ( FloatMatrix & x, const double & a );
-OOFEM_EXPORT FloatMatrix operator *( const FloatMatrix & a, const FloatMatrix & b ) ;
-OOFEM_EXPORT FloatArray operator *( const FloatMatrix & a, const FloatArray & b ) ;
-OOFEM_EXPORT FloatMatrix operator +( const FloatMatrix & a, const FloatMatrix & b ) ;
-OOFEM_EXPORT FloatMatrix operator -( const FloatMatrix & a, const FloatMatrix & b ) ;
-OOFEM_EXPORT FloatMatrix &operator += ( FloatMatrix & a, const FloatMatrix & b ) ;
-OOFEM_EXPORT FloatMatrix &operator -= ( FloatMatrix & a, const FloatMatrix & b ) ;
+#ifndef _USE_EIGEN
+    //@name operators
+    //@{
+    /// Vector multiplication by scalar
+    OOFEM_EXPORT FloatMatrix &operator *= ( FloatMatrix & x, const double & a );
+    OOFEM_EXPORT FloatMatrix operator *( const FloatMatrix & a, const FloatMatrix & b ) ;
+    OOFEM_EXPORT FloatArray operator *( const FloatMatrix & a, const FloatArray & b ) ;
+    OOFEM_EXPORT FloatMatrix operator +( const FloatMatrix & a, const FloatMatrix & b ) ;
+    OOFEM_EXPORT FloatMatrix operator -( const FloatMatrix & a, const FloatMatrix & b ) ;
+    OOFEM_EXPORT FloatMatrix &operator += ( FloatMatrix & a, const FloatMatrix & b ) ;
+    OOFEM_EXPORT FloatMatrix &operator -= ( FloatMatrix & a, const FloatMatrix & b ) ;
+    //@}
+#endif
 
-//@}
 
 } // end namespace oofem
 #endif // flotmtrx_h

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -101,6 +101,7 @@ public:
     constexpr static int Dim = 2;
     typedef double Scalar;
 
+    typedef int Index;
     /**
      * Creates matrix of given size.
      * @param n Number of rows.
@@ -159,20 +160,22 @@ public:
      * @param i Required number of rows.
      * @param j Required number of columns.
      */
-    void checkBounds(std::size_t i, std::size_t j) const;
+    void checkBounds(Index i, Index j) const;
     /// Returns number of rows of receiver.
-    inline int giveNumberOfRows() const { return (int)nRows; }
-    inline std::size_t giveRowSize() const { return nRows; }
+    //[[deprecated("use rows() instead")]]
+    inline int giveNumberOfRows() const { return rows(); }
+    inline int rows() const { return (int)nRows; }
 
     /// Returns number of columns of receiver.
-    inline int giveNumberOfColumns() const { return (int)nColumns; }
-    inline std::size_t giveColSize() const { return nColumns; }
+    //[[deprecated("use cols() instead")]]
+    inline int giveNumberOfColumns() const { return cols(); }
+    inline int cols() const { return (int)nColumns; }
 
 
     /// Returns nonzero if receiver is square matrix.
-    inline bool isSquare() const { return nRows == nColumns; }
+    inline bool isSquare() const { return rows() == cols(); }
     /// Tests for empty matrix.
-    inline bool isNotEmpty() const { return nRows > 0 && nColumns > 0; }
+    inline bool isNotEmpty() const { return rows() > 0 && cols() > 0; }
 
     /// Returns true if no element is NAN or infinite
     bool isAllFinite() const;
@@ -185,10 +188,7 @@ public:
      */
     inline double at(std::size_t i, std::size_t j) const
     {
-#ifndef NDEBUG
-        this->checkBounds(i, j);
-#endif
-        return values [ ( j - 1 ) * nRows + i - 1 ];
+        return (*this)(i-1,j-1);
     }
     /**
      * Coefficient access function. Returns value of coefficient at given
@@ -198,10 +198,7 @@ public:
      */
     inline double &at(std::size_t i, std::size_t j)
     {
-#ifndef NDEBUG
-        this->checkBounds(i, j);
-#endif
-        return values [ ( j - 1 ) * nRows + i - 1 ];
+        return (*this)(i-1,j-1);
     }
 
     /**
@@ -382,7 +379,7 @@ public:
      * @param topCol Index of top column of sub-matrix.
      * @param bottomCol index of bottom column of sub-matrix.
      */
-    void beSubMatrixOf(const FloatMatrix &src, std::size_t topRow, std::size_t bottomRow, std::size_t topCol, std::size_t bottomCol);
+    void beSubMatrixOf(const FloatMatrix &src, Index topRow, Index bottomRow, Index topCol, Index bottomCol);
     /**
      * Modifies receiver to be a sub-matrix of another matrix.
      * @param src Matrix from which sub-matrix is taken
@@ -528,13 +525,13 @@ public:
      * @param rows New number of rows.
      * @param cols New number of columns.
      */
-    void resize(std::size_t rows, std::size_t cols);
+    void resize(Index rows, Index cols);
     /**
      * Checks size of receiver towards requested bounds.
      * If dimension mismatch, size is adjusted accordingly.
      * Note: New coefficients are initialized to zero, old are kept.
      */
-    void resizeWithData(std::size_t, std::size_t);
+    void resizeWithData(Index, Index);
 
     /// Sets size of receiver to be an empty matrix. It will have zero rows and zero columns size.
     void clear() {

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -38,6 +38,7 @@
 #include "oofemenv.h"
 #include "contextioresulttype.h"
 #include "contextmode.h"
+#include "numerics.h"
 
 #include <vector>
 #include <iosfwd>
@@ -90,18 +91,8 @@ protected:
     std :: vector< double >values;
 
 public:
-    /// @name Iterator for for-each loops (columns-wise order):
-    //@{
-    std::vector< double > :: iterator begin() { return this->values.begin(); }
-    std::vector< double > :: iterator end() { return this->values.end(); }
-    std::vector< double > :: const_iterator begin() const { return this->values.begin(); }
-    std::vector< double > :: const_iterator end() const { return this->values.end(); }
-    //@}
-
     constexpr static int Dim = 2;
     typedef double Scalar;
-
-    typedef int Index;
     /**
      * Creates matrix of given size.
      * @param n Number of rows.
@@ -111,27 +102,27 @@ public:
     /// Creates zero sized matrix.
     FloatMatrix() : nRows(0), nColumns(0), values() {}
     /**
-     * Constructor. Creates float matrix from float vector. Vector may be stored row wise
+     * Creates float matrix from float vector. Vector may be stored row wise
      * or column wise, depending on second parameter.
      * @param vector Float vector from which matrix is constructed
      * @param transpose If false (default) then a matrix of size (vector->giveSize(),1)
      * will be created and initialized, if true then a matrix of size (1,vector->giveSize())
      * will be created.
      */
-    FloatMatrix(const FloatArray &vector, bool transpose = false);
+    static FloatMatrix fromArray(const FloatArray &vector, bool transpose = false);
     /// Copy constructor.
     FloatMatrix(const FloatMatrix &mat) : nRows(mat.nRows), nColumns(mat.nColumns), values(mat.values) {}
     /// Copy constructor.
     FloatMatrix(FloatMatrix && mat) noexcept : nRows(mat.nRows), nColumns(mat.nColumns), values( std :: move(mat.values) ) {}
     /// Initializer list constructor.
     FloatMatrix(std :: initializer_list< std :: initializer_list< double > >mat);
+    /// Assignment operator.
+    FloatMatrix &operator=(std :: initializer_list< std :: initializer_list< double > >mat);
     /// Initializer list constructor.
     template<std::size_t M, std::size_t N>
     FloatMatrix(const FloatMatrixF<N,M> &src) : nRows(N), nColumns(M), values(src.begin(), src.end()) { }
     /// Assignment operator.
-    FloatMatrix &operator=(std :: initializer_list< std :: initializer_list< double > >mat);
-    /// Assignment operator.
-    FloatMatrix &operator=(std :: initializer_list< FloatArray >mat);
+    static FloatMatrix fromCols(std :: initializer_list< FloatArray >mat);
     /// Assignment operator, adjusts size of the receiver if necessary.
     FloatMatrix &operator=(const FloatMatrix &mat) {
         nRows = mat.nRows;
@@ -500,13 +491,6 @@ public:
      * Changes sign of receiver values.
      */
     void negated();
-    /**
-     * Assigns to receiver one column or one row matrix containing vector.
-     * @param vector Source vector.
-     * @param transposed If false then (vector->giveSize(),1) FloatMatrix is assigned
-     * else (1,vector->giveSize()) FloatMatrix is assigned.
-     */
-    void initFromVector(const FloatArray &vector, bool transposed);
     /**
      * Initializes the lower half of the receiver according to the upper half.
      */

--- a/src/oofemlib/floatmatrix.h
+++ b/src/oofemlib/floatmatrix.h
@@ -118,9 +118,8 @@ public:
     FloatMatrix(std :: initializer_list< std :: initializer_list< double > >mat);
     /// Assignment operator.
     FloatMatrix &operator=(std :: initializer_list< std :: initializer_list< double > >mat);
-    /// Initializer list constructor.
     template<std::size_t M, std::size_t N>
-    FloatMatrix(const FloatMatrixF<N,M> &src) : nRows(N), nColumns(M), values(src.begin(), src.end()) { }
+    FloatMatrix(const FloatMatrixF<N,M> &src) { assignFloatMatrixF(src); }
     /// Assignment operator.
     static FloatMatrix fromCols(std :: initializer_list< FloatArray >mat);
     /// Assignment operator, adjusts size of the receiver if necessary.
@@ -138,11 +137,14 @@ public:
     }
     /// Assignment operator, adjusts size of the receiver if necessary.
     template<std::size_t N, std::size_t M>
+    void assignFloatMatrixF(const FloatMatrixF<N,M> &mat){
+        nRows=N; nColumns=M; values.resize(N*M);
+        for(Index c=0; c<cols(); c++) for(Index r=0; r<rows(); r++) (*this)(r,c)=mat(r,c);
+    }
+    template<std::size_t N, std::size_t M>
     FloatMatrix &operator=(const FloatMatrixF<N,M> &mat) {
-        nRows = N;
-        nColumns = M;
-        values.assign(mat.begin(), mat.end());
-        return * this;
+        this->assignFloatMatrixF(mat);
+        return *this;
     }
 
     /**

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -736,7 +736,7 @@ FloatArrayF<N> column(const FloatMatrixF<N,M> &mat, std::size_t col)
  * Symmetrizes and stores a matrix in Voigt form:
  * x_11, x_22, x_33, x_23, x_13, x_12, x_32, x_31, x_21
  */
-inline FloatMatrixF<3,3> from_voigt_form(const FloatArrayF<9> &v)
+inline FloatMatrixF<3,3> from_voigt_form_9(const FloatArrayF<9> &v)
 {
     return {
         v[0], v[8], v[7], 
@@ -749,7 +749,7 @@ inline FloatMatrixF<3,3> from_voigt_form(const FloatArrayF<9> &v)
  * Symmetrizes and stores a matrix in Voigt form:
  * x_11, x_22, x_33, x_23, x_13, x_12, x_32, x_31, x_21
  */
-inline FloatArrayF<9> to_voigt_form(const FloatMatrixF<3,3> &t)
+inline FloatArrayF<9> to_voigt_form_33(const FloatMatrixF<3,3> &t)
 {
     return {
         t(0, 0),
@@ -768,7 +768,7 @@ inline FloatArrayF<9> to_voigt_form(const FloatMatrixF<3,3> &t)
  * Symmetrizes and stores a matrix in stress Voigt form:
  * s_11, s_22, s_33, s_23, s_13, s_12
  */
-inline FloatMatrixF<3,3> from_voigt_stress(const FloatArrayF<6> &v)
+inline FloatMatrixF<3,3> from_voigt_stress_6(const FloatArrayF<6> &v)
 {
     return {
         v[0], v[5], v[4], 
@@ -781,7 +781,7 @@ inline FloatMatrixF<3,3> from_voigt_stress(const FloatArrayF<6> &v)
  * Symmetrizes and stores a matrix in stress Voigt form:
  * s_11, s_22, s_33, s_23, s_13, s_12
  */
-inline FloatArrayF<6> to_voigt_stress(const FloatMatrixF<3,3> &t)
+inline FloatArrayF<6> to_voigt_stress_33(const FloatMatrixF<3,3> &t)
 {
     return {
         t(0, 0),
@@ -797,7 +797,7 @@ inline FloatArrayF<6> to_voigt_stress(const FloatMatrixF<3,3> &t)
  * Converts Voigt vector to matrix form:
  * e_11, e_22, e_33, v_23, v_13, v_12
  */
-inline FloatMatrixF<3,3> from_voigt_strain(const FloatArrayF<6> &v)
+inline FloatMatrixF<3,3> from_voigt_strain_6(const FloatArrayF<6> &v)
 {
     return {
         v[0], 0.5*v[5], 0.5*v[4],
@@ -810,7 +810,7 @@ inline FloatMatrixF<3,3> from_voigt_strain(const FloatArrayF<6> &v)
  * Symmetrizes and stores a matrix in strain Voigt form:
  * e_11, e_22, e_33, v_23, v_13, v_12
  */
-inline FloatArrayF<6> to_voigt_strain(const FloatMatrixF<3,3> &t)
+inline FloatArrayF<6> to_voigt_strain_33(const FloatMatrixF<3,3> &t)
 {
     return {
         t(0, 0),

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -63,14 +63,6 @@ protected:
     std::array< double, N*M > values;
 
 public:
-    /// @name Iterator for for-each loops:
-    //@{
-    auto begin() { return this->values.begin(); }
-    auto end() { return this->values.end(); }
-    auto begin() const { return this->values.begin(); }
-    auto end() const { return this->values.end(); }
-    //@}
-
     /**
      * Constructor (values are specified column-wise)
      * @note The syntax {{x,y,z},{...}} can be achieved by nested initializer_list, but 

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -217,6 +217,16 @@ public:
         return x;
     }
     
+    static FloatMatrixF<N,M> fromColumns(FloatArrayF<N> const (&x)[M]) noexcept
+    {
+        FloatMatrixF<N,M> ret;
+        for (Index r = 0; r < N; ++r) {
+            for (Index c = 0; c < M; ++c) {
+                ret(r,c) = x[c][r];
+            }
+        }
+    }
+
     /// Assemble x into self.
     template<std::size_t R, std::size_t C>
     inline void assemble(const FloatMatrixF<R,C> &x, int const (&r)[R], int const (&c)[C] )

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -80,7 +80,7 @@ public:
         assert(ini.size()==rows()*cols());
         int i=0;
         for(const double& x: ini){
-            (*this)(i/rows(),i%rows())=x;
+            (*this)(i%rows(),i/rows())=x;
             i++;
         }
     }

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -51,6 +51,9 @@
 
 namespace oofem {
 
+
+#define _LOOP_FLOATMATRIX(M,r,c) for(Index c=0; c<M.cols(); c++) for(Index r=0; r<M.rows(); r++)
+
 /**
  * Implementation of matrix containing floating point numbers.
  * @author Mikael Öhman
@@ -460,9 +463,7 @@ template<std::size_t N, std::size_t M>
 FloatMatrixF<N,M> operator * ( double a, const FloatMatrixF<N,M> & x )
 {
     FloatMatrixF<N,M> out;
-    for ( std::size_t i = 0; i < N*M; ++i ) {
-        out[i] = x[i] * a;
-    }
+    _LOOP_FLOATMATRIX(x,r,c) out(r,c)=x(r,c)*a;
     return out;
 }
 
@@ -476,9 +477,7 @@ template<std::size_t N, std::size_t M>
 FloatMatrixF<N,M> operator / ( const FloatMatrixF<N,M> & x, double a )
 {
     FloatMatrixF<N,M> out;
-    for ( std::size_t i = 0; i < N*M; ++i ) {
-        out[i] = x[i] / a;
-    }
+    _LOOP_FLOATMATRIX(x,r,c) out(r,c)=x(r,c)/a;
     return out;
 }
 
@@ -486,9 +485,7 @@ template<std::size_t N, std::size_t M>
 FloatMatrixF<N,M> operator + ( const FloatMatrixF<N,M> & x, const FloatMatrixF<N,M> & y )
 {
     FloatMatrixF<N,M> out;
-    for ( std::size_t i = 0; i < N*M; ++i ) {
-        out[i] = x[i] + y[i];
-    }
+    _LOOP_FLOATMATRIX(x,r,c) out(r,c)=x(r,c)+y(r,c);
     return out;
 }
 
@@ -496,36 +493,28 @@ template<std::size_t N, std::size_t M>
 FloatMatrixF<N,M> operator - ( const FloatMatrixF<N,M> & x, const FloatMatrixF<N,M> & y )
 {
     FloatMatrixF<N,M> out;
-    for ( std::size_t i = 0; i < N*M; ++i ) {
-        out[i] = x[i] - y[i];
-    }
+    _LOOP_FLOATMATRIX(x,r,c) out(r,c)=x(r,c)-y(r,c);
     return out;
 }
 
 template<std::size_t N, std::size_t M>
 FloatMatrixF<N,M> &operator += ( FloatMatrixF<N,M> & x, const FloatMatrixF<N,M> & y )
 {
-    for ( std::size_t i = 0; i < N*M; ++i ) {
-        x[i] += y[i];
-    }
+    _LOOP_FLOATMATRIX(x,r,c) x(r,c)+=y(r,c);
     return x;
 }
 
 template<std::size_t N, std::size_t M>
 FloatMatrixF<N,M> &operator -= ( FloatMatrixF<N,M> & x, const FloatMatrixF<N,M> & y )
 {
-    for ( std::size_t i = 0; i < N*M; ++i ) {
-        x[i] -= y[i];
-    }
+    _LOOP_FLOATMATRIX(x,r,c) x(r,c)-=y(r,c);
     return x;
 }
 
 template<std::size_t N, std::size_t M>
 FloatMatrixF<N,M> &operator *= ( FloatMatrixF<N,M> & x, double a )
 {
-    for ( std::size_t i = 0; i < N*M; ++i ) {
-        x[i] *= a;
-    }
+    _LOOP_FLOATMATRIX(x,r,c) x(r,c)*=a;
     return x;
 }
 
@@ -1016,9 +1005,7 @@ template<std::size_t N>
 double frobeniusNorm(const FloatMatrixF<N,N> &mat)
 {
     double n = 0.;
-    for ( std::size_t i = 0; i < N*N; ++i ) {
-        n += mat[i] * mat[i];
-    }
+    _LOOP_FLOATMATRIX(mat,r,c) n+=mat(r,c)*mat(r,c);
     return std::sqrt( n );
     //return std::sqrt( std::inner_product(mat.values.begin(), mat.values.end(), mat.values.begin(), 0.) );
 }

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -87,9 +87,9 @@ public:
     FloatMatrixF(const FloatMatrix &mat)
     {
 #ifndef NDEBUG
-        if ( mat.giveNumberOfRows() != N || mat.giveNumberOfColumns() != M ) {
+        if ( mat.rows() != N || mat.cols() != M ) {
             throw std::out_of_range("Can't convert dynamic float matrix of size " + 
-                std::to_string(mat.giveNumberOfRows()) + "x" + std::to_string(mat.giveNumberOfRows()) + 
+                std::to_string(mat.rows()) + "x" + std::to_string(mat.cols()) + 
                 " to fixed size " + std::to_string(N) + "x" + std::to_string(M));
         }
 #endif

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -93,7 +93,11 @@ public:
                 " to fixed size " + std::to_string(N) + "x" + std::to_string(M));
         }
 #endif
-        std::copy_n(mat.begin(), N*M, values.begin());
+        #if 0
+             std::copy_n(mat.begin(), N*M, values.begin());
+        #else
+             for(Index c=0; c<mat.cols(); c++) for(Index r=0; r<mat.rows(); r++) (*this)(r,c)=mat(r,c);
+        #endif
     }
     FloatMatrixF(FloatArrayF<N> const (&x)[M]) noexcept
     {

--- a/src/oofemlib/floatmatrixf.h
+++ b/src/oofemlib/floatmatrixf.h
@@ -70,8 +70,20 @@ public:
     OOFEM_EIGEN_DERIVED(FloatMatrixF,MatrixRCd_NM);
     const double *data() const { return MatrixRCd_NM::data(); }
     double *data() { return MatrixRCd_NM::data(); }
-    template<typename... V, class = typename std::enable_if_t<sizeof...(V) == M*N>>
-    FloatMatrixF(V... x) { this->array()=NaN; /* TODO */}
+    template<
+        typename... Args,
+        class = typename std::enable_if_t<sizeof...(Args) == M*N>,
+        class = std::enable_if_t<(std::conjunction_v<std::is_same<double, Args>...>)>
+    >
+    FloatMatrixF(Args... args) {
+        std::initializer_list<double> ini{ args ... };
+        assert(ini.size()==rows()*cols());
+        int i=0;
+        for(const double& x: ini){
+            (*this)(i/rows(),i%rows())=x;
+            i++;
+        }
+    }
     // redefine because of signedness (move to Index in the future pehaps)
     std::size_t rows() const{ return MatrixRCd_NM::rows(); }
     std::size_t cols() const{ return MatrixRCd_NM::cols(); }

--- a/src/oofemlib/gpexportmodule.C
+++ b/src/oofemlib/gpexportmodule.C
@@ -138,7 +138,7 @@ GPExportModule :: doOutput(TimeStep *tStep, bool forcedOutput)
                     // export internal variables
                     for ( auto vartype : vartypes ) {
                         elem->giveIPValue(intvar, gp, ( InternalStateType )vartype, tStep);
-                        fprintf(stream, "%d ", intvar.giveSize());
+                        fprintf(stream, "%d ", (int)intvar.giveSize());
                         for ( auto &val : intvar ) {
                             fprintf( stream, "%.6e ", val );
                         }

--- a/src/oofemlib/numerics.h
+++ b/src/oofemlib/numerics.h
@@ -37,21 +37,20 @@
 
 #ifdef _USE_EIGEN
     #define EIGEN_INITIALIZE_MATRICES_BY_ZERO
-    // #include<Eigen/Core>
+    #include<Eigen/Core>
 #endif
 
 
 namespace oofem{
-    typedef int Index;
 
 
     #ifdef _USE_EIGEN
         #define OOFEM_EIGEN_DERIVED(MyKlass,EigenBase) \
-        MyKlass(void): EigenBase() {} \
-        /* This constructor allows you to construct MyKlass from Eigen expressions */ \
-        template<typename OtherDerived> MyKlass(const Eigen::MatrixBase<OtherDerived>& other): EigenBase(other) { } \
-        /* This method allows you to assign Eigen expressions to MyKlass */ \
-        template<typename OtherDerived> MyKlass& operator=(const Eigen::MatrixBase<OtherDerived>& other) { this->EigenBase::operator=(other); return *this; }
+            MyKlass(void): EigenBase() {} \
+            /* This constructor allows you to construct MyKlass from Eigen expressions */ \
+            template<typename OtherDerived> MyKlass(const Eigen::MatrixBase<OtherDerived>& other): EigenBase(other) { } \
+            /* This method allows you to assign Eigen expressions to MyKlass */ \
+            template<typename OtherDerived> MyKlass& operator=(const Eigen::MatrixBase<OtherDerived>& other) { this->EigenBase::operator=(other); return *this; }
 
         typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor> MatrixXXd;
         typedef Eigen::Matrix<double,Eigen::Dynamic,1> VectorXd;
@@ -67,9 +66,13 @@ namespace oofem{
 
         class FloatArray;
         class FloatMatrix;
-        template<Index N> class FloatArrayF;
-        template<Index R, Index C> class FloatMatrixF;
+        template<std::size_t N> class FloatArrayF;
+        template<std::size_t R, std::size_t C> class FloatMatrixF;
         const double NaN(std::numeric_limits<double>::signaling_NaN());
+        // using Eigen::Index;
+        typedef int Index;
+    #else
+        typedef int Index;
     #endif
 
 

--- a/src/oofemlib/numerics.h
+++ b/src/oofemlib/numerics.h
@@ -40,10 +40,7 @@
     #include<Eigen/Core>
 #endif
 
-
 namespace oofem{
-
-
     #ifdef _USE_EIGEN
         #define OOFEM_EIGEN_DERIVED(MyKlass,EigenBase) \
             MyKlass(void): EigenBase() {} \
@@ -74,8 +71,6 @@ namespace oofem{
     #else
         typedef int Index;
     #endif
-
-
 } // end namespace oofem
 
 

--- a/src/oofemlib/numerics.h
+++ b/src/oofemlib/numerics.h
@@ -1,0 +1,128 @@
+/*
+ *
+ *                 #####    #####   ######  ######  ###   ###
+ *               ##   ##  ##   ##  ##      ##      ## ### ##
+ *              ##   ##  ##   ##  ####    ####    ##  #  ##
+ *             ##   ##  ##   ##  ##      ##      ##     ##
+ *            ##   ##  ##   ##  ##      ##      ##     ##
+ *            #####    #####   ##      ######  ##     ##
+ *
+ *
+ *             OOFEM : Object Oriented Finite Element Code
+ *
+ *               Copyright (C) 1993 - 2013   Borek Patzak
+ *
+ *
+ *
+ *       Czech Technical University, Faculty of Civil Engineering,
+ *   Department of Structural Mechanics, 166 29 Prague, Czech Republic
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef numerics_h
+#define numerics_h
+
+#ifdef _USE_EIGEN
+    #define EIGEN_INITIALIZE_MATRICES_BY_ZERO
+    // #include<Eigen/Core>
+#endif
+
+
+namespace oofem{
+    typedef int Index;
+
+
+    #ifdef _USE_EIGEN
+        #define OOFEM_EIGEN_DERIVED(MyKlass,EigenBase) \
+        MyKlass(void): EigenBase() {} \
+        /* This constructor allows you to construct MyKlass from Eigen expressions */ \
+        template<typename OtherDerived> MyKlass(const Eigen::MatrixBase<OtherDerived>& other): EigenBase(other) { } \
+        /* This method allows you to assign Eigen expressions to MyKlass */ \
+        template<typename OtherDerived> MyKlass& operator=(const Eigen::MatrixBase<OtherDerived>& other) { this->EigenBase::operator=(other); return *this; }
+
+        typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,Eigen::ColMajor> MatrixXXd;
+        typedef Eigen::Matrix<double,Eigen::Dynamic,1> VectorXd;
+
+        /* typedef for fixed-size base classes */
+        // columns vectors are required to be col-major, even though it makes not difference for storage
+        template<std::size_t N>
+        using VectorNd = Eigen::Matrix<double,N,1,Eigen::ColMajor>; 
+
+        // FloatMatrixF with N==1 (one row) must be RowMajor
+        template<std::size_t R, std::size_t C>
+        using MatrixRCd = Eigen::Matrix<double,R,C,(R==1?Eigen::RowMajor:Eigen::ColMajor)>;
+
+        class FloatArray;
+        class FloatMatrix;
+        template<Index N> class FloatArrayF;
+        template<Index R, Index C> class FloatMatrixF;
+        const double NaN(std::numeric_limits<double>::signaling_NaN());
+    #endif
+
+
+} // end namespace oofem
+
+
+
+#ifdef __LAPACK_MODULE
+// Some forward declarations for LAPACK. Remember to append the underscore to the function name.
+// consumed in floatmatrix.C and floatarray.C
+extern "C" {
+    extern void dgemv_(const char *trans, const int *m, const int *n, const double *alpha, const double *a, const int *lda, const double *x,
+                       const int *incx, const double *beta, double *y, const int *incy, int aColumns, int xSize, int ySize);
+    // Y = Y + alpha * X
+    extern void daxpy_(const int *n, const double *alpha, const double *x, const int *incx, double *y, const int *incy, int xsize, int ysize);
+
+    /// Computes the reciprocal condition number for a LU decomposed function.
+    extern void dgecon_(const char *norm, const int *n, const double *a, const int *lda,
+                        const double *anorm, double *rcond, double *work, int *iwork, int *info, int norm_len);
+    /// Replaces a with the LU-decomposition.
+    extern int dgetrf_(const int *m, const int *n, double *a, const int *lda, int *lpiv, int *info);
+    /// Replaces a with its inverse.
+    extern int dgetri_(const int *n, double *a, const int *lda, int *ipiv, double *work, const int *lwork, int *info);
+    /// Solves a system of equations.
+    extern int dgesv_(const int *n, const int *nrhs, double *a, const int *lda, int *ipiv, const double *b, const int *ldb, int *info);
+    /// Computes the norm.
+    extern double dlange_(const char *norm, const int *m, const int *n, const double *a, const int *lda, double *work, int norm_len);
+    /// Computes eigenvalues and vectors.
+    extern int dsyevx_(const char *jobz,  const char *range, const char *uplo, const int *n, double *a, const int *lda,
+                       const double *vl, const double *vu, const int *il, const int *iu,
+                       const double *abstol, int *m, double *w, double *z, const int *ldz,
+                       double *work, int *lwork, int *iwork, int *ifail, int *info,
+                       int jobz_len, int range_len, int uplo_len);
+    /// Solves system which has been LU-factorized.
+    extern void dgetrs_(const char *trans, const int *n, const int *nrhs, double *a, const int *lda, int *ipiv, const double *b, const int *ldb, int *info);
+    /// General matrix multiplication
+    extern void dgemm_(const char *transa, const char *transb, const int *m, const int *n, const int *k, const double *alpha,
+                       const double *a, const int *lda, const double *b, const int *ldb, const double *beta, double *c, const int *ldc,
+                       int a_columns, int b_columns, int c_columns);
+    /// General dyad product of vectors
+    extern void dger_(const int *m, const int *n, const double *alpha, const double *x, const int *incx,
+                      const double *y, const int *incy, double *a, const int *lda,
+                      int x_len, int y_len, int a_columns);
+    /// Symmetric dyad product of vector
+    extern void dsyr_(const char *uplo, const int *n, const double *alpha, const double *x, const int *incx,
+                      double *a, const int *lda, int x_len, int a_columns);
+    /// Y = Y + alpha * X
+    extern void daxpy_(const int *n, const double *alpha, const double *x, const int *incx, double *y, const int *incy, int xsize, int ysize);
+    /// X = alpha * X
+    extern void dscal_(const int *n, const double *alpha, const double *x, const int *incx, int size);
+}
+#endif
+
+
+#endif // numerics_h
+

--- a/src/oofemlib/prescribedmean.C
+++ b/src/oofemlib/prescribedmean.C
@@ -132,7 +132,7 @@ PrescribedMean :: assemble(SparseMtrx &answer, TimeStep *tStep, CharType type,
             }
 
             // delta p part:
-            temp = N * (scale * detJ * gp->giveWeight() / domainSize);
+            temp = FloatMatrix::fromArray(N * (scale * detJ * gp->giveWeight() / domainSize));
             tempT.beTranspositionOf(temp);
 #ifdef _OPENMP
             if (lock) omp_set_lock(static_cast<omp_lock_t*>(lock));

--- a/src/oofemlib/vtkexportmodule.C
+++ b/src/oofemlib/vtkexportmodule.C
@@ -688,7 +688,7 @@ VTKExportModule :: exportIntVarAs(InternalStateType valID, InternalStateValueTyp
                 fprintf(stream, "%e ", 0.0);
             }
         } else if ( type == ISVT_VECTOR ) {
-            jsize = min( 3, val->giveSize() );
+            jsize = min( 3, (int)val->giveSize() );
             for ( j = 1; j <= jsize; j++ ) {
                 fprintf( stream, "%e ", val->at(j) );
             }
@@ -855,7 +855,7 @@ VTKExportModule :: exportPrimVarAs(UnknownType valID, FILE *stream, TimeStep *tS
                 fprintf(stream, "%e ", 0.0);
             }
         } else if ( type == ISVT_VECTOR ) {
-            jsize = min( 3, iVal.giveSize() );
+            jsize = min( 3, (int)iVal.giveSize() );
             //rotate back from nodal CS to global CS if applies
             if ( d->giveNode( dman->giveNumber() )->hasLocalCS() ) {
                 iVal.resize(3);

--- a/src/sm/Contact/ActiveBc/node2nodelagrangianmultipliercontact.C
+++ b/src/sm/Contact/ActiveBc/node2nodelagrangianmultipliercontact.C
@@ -110,7 +110,7 @@ Node2NodeLagrangianMultiplierContact :: assemble(SparseMtrx &answer, TimeStep *t
 #ifdef _OPENMP
             if (lock) omp_set_lock(static_cast<omp_lock_t*>(lock));
 #endif
-            answer.assemble(lambdaeq.at(pos - 1), one);
+            answer.assemble(lambdaeq.at(pos - 1), FloatMatrix::fromArray(one));
 #ifdef _OPENMP
             if (lock) omp_unset_lock(static_cast<omp_lock_t*>(lock));
 #endif
@@ -208,7 +208,7 @@ Node2NodeLagrangianMultiplierContact :: computeTangentFromContact(FloatMatrix &a
     FloatArray Nv;
     this->computeGap(gap, masterNode, slaveNode, tStep);
     this->computeNormalMatrixAt(Nv, masterNode, slaveNode, tStep);
-    answer.initFromVector(Nv, false);
+    answer=FloatMatrix::fromArray(Nv, false);
 
     return gap;
     //answer.times(this->penalty);

--- a/src/sm/Contact/ActiveBc/node2nodelagrangianmultipliercontact.C
+++ b/src/sm/Contact/ActiveBc/node2nodelagrangianmultipliercontact.C
@@ -247,7 +247,7 @@ Node2NodeLagrangianMultiplierContact :: computeNormalMatrixAt(FloatArray &answer
 {
     const auto &xs = slaveNode->giveCoordinates();
     const auto &xm = masterNode->giveCoordinates();
-    auto normal = xs - xm;
+    FloatArray normal = xs - xm;
     double norm = normal.computeNorm();
     if ( norm < 1.0e-8 ) {
         OOFEM_ERROR("Couldn't compute normal between master node (num %d) and slave node (num %d), nodes are too close to each other.", masterNode->giveGlobalNumber(), slaveNode->giveGlobalNumber() );
@@ -256,10 +256,10 @@ Node2NodeLagrangianMultiplierContact :: computeNormalMatrixAt(FloatArray &answer
     }
     // The normal is not updated for node2node which is for small deformations only
     // C = {n -n}
-    answer = {
+    answer = Vec4(
         normal.at(1), normal.at(2),
         -normal.at(1), -normal.at(2)
-    };
+    );
 }
 
 

--- a/src/sm/Contact/ActiveBc/node2nodepenaltycontact.C
+++ b/src/sm/Contact/ActiveBc/node2nodepenaltycontact.C
@@ -224,7 +224,7 @@ Node2NodePenaltyContact :: computeNormalMatrixAt(FloatArray &answer, Node *maste
 {
     const auto &xs = slaveNode->giveCoordinates();
     const auto &xm = masterNode->giveCoordinates();
-    auto normal = xs - xm;
+    FloatArray normal = xs - xm;
     double norm = normal.computeNorm();
     if ( norm < 1.0e-8 ) {
         OOFEM_ERROR("Couldn't compute normal between master node (num %d) and slave node (num %d), nodes are too close to each other.",
@@ -234,10 +234,10 @@ Node2NodePenaltyContact :: computeNormalMatrixAt(FloatArray &answer, Node *maste
     }
     // The normal is not updated for node2node which is for small deformations only
     // C = {n -n}
-    answer = {
+    answer = Vec4(
         normal.at(1), normal.at(2),
         -normal.at(1), -normal.at(2)
-    };
+    );
 }
 
 

--- a/src/sm/Contact/celnode2node.C
+++ b/src/sm/Contact/celnode2node.C
@@ -53,10 +53,10 @@ int
 Node2NodeContact :: instanciateYourself(DataReader &dr)
 {
     // compute normal as direction vector from master node to slave node
-    const auto &xs = this->slaveNode->giveCoordinates();
-    const auto &xm = this->masterNode->giveCoordinates();
+    const FloatArray &xs = this->slaveNode->giveCoordinates();
+    const FloatArray &xm = this->masterNode->giveCoordinates();
 
-    auto _normal = xs - xm;
+    FloatArray _normal = xs - xm;
     double norm = _normal.computeNorm();
     if ( norm < 1.0e-8 ) {
         OOFEM_ERROR("Couldn't compute normal between master node (num %d) and slave node (num %d), nodes are too close to each other.", 

--- a/src/sm/Deprecated/prescribedgenstrainshell7.C
+++ b/src/sm/Deprecated/prescribedgenstrainshell7.C
@@ -124,8 +124,11 @@ PrescribedGenStrainShell7 :: evalCovarBaseVectorsAt(FloatArray &genEps, double z
     auto g1 = dxdxi1 + fac1*dmdxi1 + fac2*dgamdxi1*m;
     auto g2 = dxdxi2 + fac1*dmdxi2 + fac2*dgamdxi2*m;
     auto g3 = fac3*m;
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Warray-bounds"
     FloatMatrixF<3,3> gcov;
     gcov.setColumn(g1,1); gcov.setColumn(g2,2); gcov.setColumn(g3,3);
+    #pragma GCC diagnostic pop
     return gcov;
 }
 

--- a/src/sm/Deprecated/prescribedgenstrainshell7.C
+++ b/src/sm/Deprecated/prescribedgenstrainshell7.C
@@ -301,6 +301,6 @@ void PrescribedGenStrainShell7 :: giveInputRecord(DynamicInputRecord &input)
     BoundaryCondition :: giveInputRecord(input);
     input.setField(this->initialGenEps, _IFT_PrescribedGenStrainShell7_initialgeneralizedstrain);
     input.setField(this->genEps, _IFT_PrescribedGenStrainShell7_generalizedstrain);
-    input.setField(this->centerCoord, _IFT_PrescribedGenStrainShell7_centercoords);
+    input.setField(FloatArray(this->centerCoord), _IFT_PrescribedGenStrainShell7_centercoords);
 }
 } // end namespace oofem

--- a/src/sm/Elements/Bars/truss3dnl.C
+++ b/src/sm/Elements/Bars/truss3dnl.C
@@ -216,7 +216,7 @@ Truss3dnl :: computeBnlMatrixAt(GaussPoint *gp, FloatMatrix &answer, TimeStep *t
   if(!lin) {
     factor /= 2;
   } 
-  Bnl.beProductOf(A,d);
+  Bnl.beProductOf(A,FloatMatrix::fromArray(d));
   Bnl.times(factor);
   answer.beTranspositionOf(Bnl);
   

--- a/src/sm/Elements/Bars/truss3dnl2.C
+++ b/src/sm/Elements/Bars/truss3dnl2.C
@@ -217,7 +217,7 @@ Truss3dnl2 :: _computeBmatrixAt(GaussPoint *gp, FloatMatrix &answer, TimeStep *t
   FloatMatrixF<6,6> A = this->giveAmatrix();
   FloatArray x(X);
   x.add(d); 
-  answer.beTProductOf(x,A);
+  answer.beTProductOf(FloatMatrix::fromArray(x),A);
   answer.times(1./l/L);
 }
 
@@ -254,7 +254,7 @@ Truss3dnl2 :: computeInitialStressStiffness(FloatMatrix &answer, MatResponseMode
   FloatMatrix xx, Axx, AxxA;
   x.add(d); 
 
-  xx.beProductTOf(x,x);
+  xx.beProductTOf(FloatMatrix::fromArray(x),FloatMatrix::fromArray(x));
   Axx.beProductOf(A,xx);
   AxxA.beProductOf(Axx,A);
   AxxA.times(1./l/l);

--- a/src/sm/Elements/GradientDamage/graddamageelement.C
+++ b/src/sm/Elements/GradientDamage/graddamageelement.C
@@ -490,7 +490,7 @@ GradientDamageElement :: computeStiffnessMatrix_du(FloatMatrix &answer, MatRespo
         dV = elem->computeVolumeAround(gp);
         if ( Ddu.giveNumberOfRows() > 0 ) {
             DduB.beTProductOf(Ddu, B);
-            FloatMatrix Ndm(Nd, true);
+            FloatMatrix Ndm=FloatMatrix::fromArray(Nd, true);
             answer.plusProductUnsym(Ndm, DduB, dV);
         } else {
             if ( answer.giveNumberOfColumns() == 0 ) {
@@ -521,7 +521,7 @@ GradientDamageElement :: computeStiffnessMatrix_dd(FloatMatrix &answer, MatRespo
         }
 
         this->computeNdMatrixAt(gp, Nd);
-        FloatMatrix Ndm(Nd, true);
+        FloatMatrix Ndm=FloatMatrix::fromArray(Nd, true);
         this->computeBdMatrixAt(gp, Bd);
         dV = elem->computeVolumeAround(gp);
 
@@ -594,7 +594,7 @@ GradientDamageElement :: computeStiffnessMatrix_ud(FloatMatrix &answer, MatRespo
         }
         dV = elem->computeVolumeAround(gp);
 
-        DudN.beProductTOf(Dud, Nd);
+        DudN.beProductTOf(Dud, FloatMatrix::fromArray(Nd));
         answer.plusProductUnsym(B, DudN, dV);
     }
 }

--- a/src/sm/Elements/MixedPressure/basemixedpressureelement.C
+++ b/src/sm/Elements/MixedPressure/basemixedpressureelement.C
@@ -333,8 +333,8 @@ BaseMixedPressureElement :: computeStiffnessMatrix_up(FloatMatrix &answer, MatRe
     for ( GaussPoint *gp : *elem->giveIntegrationRule(0) ) {
         this->computeVolumetricBmatrixAt(gp, Bvol, elem);
         this->computePressureNMatrixAt(gp, N_p);
-        FloatMatrix mNp(N_p, true);
-        FloatMatrix mBvol(Bvol, true);
+        FloatMatrix mNp=FloatMatrix::fromArray(N_p, true);
+        FloatMatrix mBvol=FloatMatrix::fromArray(Bvol, true);
 
         dV = elem->computeVolumeAround(gp);
         answer.plusProductUnsym(mBvol, mNp, -dV);
@@ -358,7 +358,7 @@ BaseMixedPressureElement :: computeStiffnessMatrix_pp(FloatMatrix &answer, MatRe
 
         mixedPressureMat->giveInverseOfBulkModulus(kappa, rMode, gp, tStep);
         this->computePressureNMatrixAt(gp, N_p);
-        FloatMatrix mN_p(N_p, true);
+        FloatMatrix mN_p=FloatMatrix::fromArray(N_p, true);
         dV = elem->computeVolumeAround(gp);
         answer.plusProductUnsym(mN_p, mN_p, -dV * kappa);
     }

--- a/src/sm/Elements/Shells/mitc4.C
+++ b/src/sm/Elements/Shells/mitc4.C
@@ -751,12 +751,12 @@ MITC4Shell::giveCharacteristicTensor(CharTensor type, GaussPoint *gp, TimeStep *
         this->computeStrainVector(localStrain, gp, tStep);
         this->computeStressVector(localStress, localStrain, gp, tStep);
         auto stress = mat->transformStressVectorTo(GtoLRotationMatrix, localStress, false);
-        return from_voigt_stress(stress);
+        return from_voigt_stress_6(stress);
     } else if ( type == GlobalStrainTensor ) {
         FloatArray localStrain;
         this->computeStrainVector(localStrain, gp, tStep);
         auto strain = mat->transformStrainVectorTo(GtoLRotationMatrix, localStrain, false);
-        return from_voigt_strain(strain);
+        return from_voigt_strain_6(strain);
     } else {
         throw std::runtime_error("unsupported tensor mode");
     }
@@ -899,11 +899,11 @@ MITC4Shell::giveIPValue(FloatArray &answer, GaussPoint *gp, InternalStateType ty
 {
     if ( type == IST_StrainTensor ) {
         auto globTensor = this->giveCharacteristicTensor(GlobalStrainTensor, gp, tStep);
-        answer = to_voigt_strain(globTensor);
+        answer = to_voigt_strain_33(globTensor);
         return 1;
     } else if ( type == IST_StressTensor ) {
         auto globTensor = this->giveCharacteristicTensor(GlobalForceTensor, gp, tStep);
-        answer = to_voigt_stress(globTensor);
+        answer = to_voigt_stress_33(globTensor);
         return 1;
     } else if ( type == IST_ShellMomentTensor || type == IST_ShellForceTensor || type == IST_CurvatureTensor || type == IST_ShellStrainTensor ) {
         int gpnXY = ( gp->giveNumber() - 1 ) / 2;

--- a/src/sm/Elements/Shells/mitc4.C
+++ b/src/sm/Elements/Shells/mitc4.C
@@ -1075,7 +1075,7 @@ double
 MITC4Shell::computeEdgeVolumeAround(GaussPoint *gp, int iEdge)
 {
     auto lcF = this->giveNodeCoordinates();
-    std::vector< FloatArray >lc;
+    std::vector< FloatArray > lc(4);
     lc [ 0 ] = lcF [ 0 ];
     lc [ 1 ] = lcF [ 1 ];
     lc [ 2 ] = lcF [ 2 ];

--- a/src/sm/Elements/Shells/mitc4.C
+++ b/src/sm/Elements/Shells/mitc4.C
@@ -880,7 +880,7 @@ MITC4Shell::givedNdx(const FloatArrayF< 3 > &coords)
     auto dn = interp_lin.evaldNdxi(coords [ { 0, 1 } ]);
     auto J = this->giveJacobian(coords);
     auto invJ = inv(J);
-    auto invJ2 = invJ({ 0, 1 }, { 0, 1 });
+    FloatMatrixF<2,2> invJ2 = invJ({ 0, 1 }, { 0, 1 });
     auto dndx = dot(invJ2, dn);
 
     auto hkx = dndx.row< 0 >();

--- a/src/sm/Elements/Shells/shell7base.C
+++ b/src/sm/Elements/Shells/shell7base.C
@@ -172,7 +172,7 @@ Shell7Base :: computeGlobalCoordinates(FloatArray &answer, const FloatArray &lco
     for ( int i = 1; i <= this->giveNumberOfDofManagers(); i++ ) {
         const auto &xbar = this->giveNode(i)->giveCoordinates();
         const auto &M = this->giveInitialNodeDirector(i);
-        answer.add(N.at(i), ( xbar + zeta * M ));
+        answer.add(N.at(i), ( xbar + FloatArray(zeta * M)));
     }
 
     return 1;

--- a/src/sm/Elements/Shells/shell7base.C
+++ b/src/sm/Elements/Shells/shell7base.C
@@ -701,9 +701,9 @@ FloatMatrixF<3,3>
 Shell7Base :: computeStressMatrix(FloatArray &genEps, GaussPoint *gp, Material *mat, TimeStep *tStep)
 {
     auto F = computeFAt(gp->giveNaturalCoordinates(), genEps, tStep);
-    auto vF = to_voigt_form(F);
+    auto vF = to_voigt_form_33(F);
     auto vP = static_cast< StructuralMaterial * >( mat )->giveFirstPKStressVector_3d(vF, gp, tStep);
-    return from_voigt_form(vP);
+    return from_voigt_form_9(vP);
 }
 
 

--- a/src/sm/Elements/Shells/shell7basexfem.C
+++ b/src/sm/Elements/Shells/shell7basexfem.C
@@ -1641,7 +1641,7 @@ Shell7BaseXFEM :: edgeEvalEnrCovarBaseVectorsAt(const FloatArrayF<3> &lcoords, c
     const auto g3 = normalize(fac3*m);                              // director field
     const auto g1 = normalize(cross(g2, g3));
 
-    return FloatMatrixF<3,3>({g1, g2, g3});
+    return FloatMatrixF<3,3>::fromColumns({g1, g2, g3});
 }
 
 

--- a/src/sm/Elements/Shells/shell7basexfem.C
+++ b/src/sm/Elements/Shells/shell7basexfem.C
@@ -2541,8 +2541,7 @@ Shell7BaseXFEM :: giveLocalNodeCoordsForExport(FloatArray &nodeLocalXi1Coords, F
 
     nodeLocalXi3Coords = { -z, -z, -z, z, z, z, -z, -z, -z, z, z, z, 0., 0., 0. };
 
-    FloatMatrix localNodeCoordsT;
-    localNodeCoordsT = {nodeLocalXi1Coords, nodeLocalXi2Coords, nodeLocalXi3Coords};
+    FloatMatrix localNodeCoordsT = FloatMatrix::fromCols({nodeLocalXi1Coords, nodeLocalXi2Coords, nodeLocalXi3Coords});
     localNodeCoords.beTranspositionOf(localNodeCoordsT);
 }
 
@@ -2593,8 +2592,7 @@ Shell7BaseXFEM :: giveLocalCZNodeCoordsForExport(FloatArray &nodeLocalXi1Coords,
 
     nodeLocalXi3Coords = { 0., 0., 0., 0., 0., 0. };
 
-    FloatMatrix localNodeCoordsT;
-    localNodeCoordsT = {nodeLocalXi1Coords, nodeLocalXi2Coords, nodeLocalXi3Coords};
+    FloatMatrix localNodeCoordsT = FloatMatrix::fromCols({nodeLocalXi1Coords, nodeLocalXi2Coords, nodeLocalXi3Coords});
     localNodeCoords.beTranspositionOf(localNodeCoordsT);
 }
 

--- a/src/sm/Elements/Shells/shell7basexfem.C
+++ b/src/sm/Elements/Shells/shell7basexfem.C
@@ -2520,9 +2520,9 @@ Shell7BaseXFEM :: giveLocalNodeCoordsForExport(FloatArray &nodeLocalXi1Coords, F
     this->computeLocalCoordinates(loc3, gs3);
 
     // Compute coordinates for the three mid nodes 
-    auto loc12 = 0.5 * (loc1 + loc2);
-    auto loc23 = 0.5 * (loc2 + loc3);
-    auto loc31 = 0.5 * (loc3 + loc1);
+    FloatArray loc12 = 0.5 * (loc1 + loc2);
+    FloatArray loc23 = 0.5 * (loc2 + loc3);
+    FloatArray loc31 = 0.5 * (loc3 + loc1);
     double a = loc1.at(1);
     double b = loc2.at(1);
     double c = loc3.at(1);
@@ -2571,9 +2571,9 @@ Shell7BaseXFEM :: giveLocalCZNodeCoordsForExport(FloatArray &nodeLocalXi1Coords,
     this->computeLocalCoordinates(loc3, gs3);
 
     // Compute coordinates for the three mid nodes 
-    auto loc12 = 0.5 * (loc1 + loc2);
-    auto loc23 = 0.5 * (loc2 + loc3);
-    auto loc31 = 0.5 * (loc3 + loc1);
+    FloatArray loc12 = 0.5 * (loc1 + loc2);
+    FloatArray loc23 = 0.5 * (loc2 + loc3);
+    FloatArray loc31 = 0.5 * (loc3 + loc1);
     double a = loc1.at(1);
     double b = loc2.at(1);
     double c = loc3.at(1);

--- a/src/sm/Elements/tet21ghostsolid.C
+++ b/src/sm/Elements/tet21ghostsolid.C
@@ -778,7 +778,7 @@ tet21ghostsolid::giveInternalForcesVectorGivenSolution(FloatArray &answer, TimeS
             momentum.add(-pressure * detJ * weight, dNv);
 
             // Conservation equation
-            divv.beTProductOf(dNv, aTotal);
+            divv.beTProductOf(FloatMatrix::fromArray(dNv), aTotal);
             divv.times(-detJ * weight);
 
             conservation.add(divv.at(1), Nlin);
@@ -937,7 +937,7 @@ tet21ghostsolid::giveInternalForcesVectorGivenSolutionDebug(FloatArray &answer, 
             momentum.add(-pressure * detJ * weight, dNv);
 
             // Conservation equation
-            divv.beTProductOf(dNv, aTotal);
+            divv.beTProductOf(FloatMatrix::fromArray(dNv), aTotal);
             divv.times(-detJ * weight);
 
             conservation.add(divv.at(1), Nlin);

--- a/src/sm/Materials/ConcreteMaterials/concretedpm.C
+++ b/src/sm/Materials/ConcreteMaterials/concretedpm.C
@@ -629,7 +629,7 @@ ConcreteDPM::initDamaged(double kappaD,
         status->setLe(helem);
     } else if ( status->giveDamage() == 0. ) {
         //auto [principalStrains, principalDir] = computePrincipalValDir(from_voigt_strain(strain)); // c++17
-        auto tmp = computePrincipalValDir(from_voigt_strain(strain) );
+        auto tmp = computePrincipalValDir(from_voigt_strain_6(strain) );
         auto principalStrains = tmp.first;
         auto principalDir = tmp.second;
         // find index of max positive principal strain
@@ -670,7 +670,7 @@ ConcreteDPM::computeDuctilityMeasureDamage(const FloatArrayF< 6 > &strain, Gauss
 
     double volStrain = tempPlasticStrain [ 0 ] + tempPlasticStrain [ 1 ] + tempPlasticStrain [ 2 ];
     //    auto principalStrain = computePrincipalValues(from_voigt_strain(strain));
-    auto principalStrain = computePrincipalValues(from_voigt_strain(tempPlasticStrain) );
+    auto principalStrain = computePrincipalValues(from_voigt_strain_6(tempPlasticStrain) );
 
     double negativeVolStrain = 0.;
     for ( int i = 0; i < 3; i++ ) {
@@ -795,7 +795,7 @@ ConcreteDPM::performRegularReturn(FloatArrayF< 6 > &effectiveStress, GaussPoint 
 
     //compute the principal directions of the stress
     //auto [help, stressPrincipalDir] = computePrincipalValDir(from_voigt_stress(effectiveStress)); // c++17
-    auto tmp = computePrincipalValDir(from_voigt_stress(effectiveStress) );
+    auto tmp = computePrincipalValDir(from_voigt_stress_6(effectiveStress) );
     auto stressPrincipalDir = tmp.second;
 
     //compute invariants from stress state
@@ -1667,7 +1667,7 @@ ConcreteDPM::computeDCosThetaDStress(const FloatArrayF< 6 > &stress) const
 
     //compute principal stresses and directions
     //auto [principalDeviatoricStress, principalDir] = computePrincipalValDir(from_voigt_stress(deviatoricStress)); // c++17
-    auto tmp = computePrincipalValDir(from_voigt_stress(deviatoricStress) );
+    auto tmp = computePrincipalValDir(from_voigt_stress_6(deviatoricStress) );
     auto principalDeviatoricStress = tmp.first;
     auto principalDir = tmp.second;
 

--- a/src/sm/Materials/ConcreteMaterials/concretedpm.C
+++ b/src/sm/Materials/ConcreteMaterials/concretedpm.C
@@ -424,7 +424,7 @@ ConcreteDPM::giveRealStressVector_3d(const FloatArrayF< 6 > &totalStrain, GaussP
     // check whether the second-order work is negative
     // (must be done !!!before!!! the update of strain and stress)
     if ( status->giveEpsLoc() < 0. ) {
-        auto strainIncrement = totalStrain - status->giveStrainVector();
+        FloatArray strainIncrement = totalStrain - status->giveStrainVector();
         auto stressIncrement = stress - FloatArrayF< 6 >(status->giveStressVector() );
         int n = strainIncrement.giveSize();
         double work = strainIncrement.dotProduct(stressIncrement, n);

--- a/src/sm/Materials/ConcreteMaterials/concretedpm2.C
+++ b/src/sm/Materials/ConcreteMaterials/concretedpm2.C
@@ -1120,7 +1120,7 @@ ConcreteDPM2::computeRateFactor(double alpha,
     const auto &strain = status->giveTempReducedStrain();
 
     //Determine the principal values of the strain
-    auto principalStrain = StructuralMaterial::computePrincipalValues(from_voigt_strain(strain) );    ///@todo CHECK
+    auto principalStrain = StructuralMaterial::computePrincipalValues(from_voigt_strain_6(strain) );    ///@todo CHECK
 
     //Determine max and min value;
     double maxStrain = -1.e20, minStrain = 1.e20;
@@ -1423,7 +1423,7 @@ ConcreteDPM2::initDamaged(double kappaD,
         status->setLe(helem);
     } else if ( status->giveDamageTension() == 0. && status->giveDamageCompression() == 0. ) {
         //auto [principalStrains, principalDir] = computePrincipalValDir(from_voigt_strain(strain)); // c++17
-        auto tmp = computePrincipalValDir(from_voigt_strain(strain) );
+        auto tmp = computePrincipalValDir(from_voigt_strain_6(strain) );
         auto principalStrains = tmp.first;
         auto principalDir = tmp.second;
 
@@ -1893,7 +1893,7 @@ ConcreteDPM2::performRegularReturn(FloatArrayF< 6 > &effectiveStress,
 
     //compute the principal directions of the stress
     //auto [helpStress, stressPrincipalDir] = StructuralMaterial :: computePrincipalValDir(from_voigt_stress(trialStress)); // c++17
-    auto tmpEig = StructuralMaterial::computePrincipalValDir( from_voigt_stress(trialStress) );
+    auto tmpEig = StructuralMaterial::computePrincipalValDir( from_voigt_stress_6(trialStress) );
     auto stressPrincipalDir = tmpEig.second;
 
     FloatArrayF< 6 >stressPrincipal;
@@ -2566,7 +2566,7 @@ ConcreteDPM2::computeAlpha(FloatArrayF< 6 > &effectiveStressTension,
                            FloatArrayF< 6 > &effectiveStressCompression,
                            const FloatArrayF< 6 > &effectiveStress) const
 {
-    auto tmp = StructuralMaterial::computePrincipalValDir(from_voigt_stress(effectiveStress) );
+    auto tmp = StructuralMaterial::computePrincipalValDir(from_voigt_stress_6(effectiveStress) );
     auto principalStress = tmp.first;
     auto stressPrincipalDir = tmp.second;
 
@@ -2870,7 +2870,7 @@ ConcreteDPM2::computeDCosThetaDStress(const FloatArrayF< 6 > &stress) const
 
     //compute principal stresses and directions
     //auto [principalDeviatoricStress, principalDir] = computePrincipalValDir(from_voigt_stress(deviatoricStress)); // c++17
-    auto tmp = computePrincipalValDir(from_voigt_stress(deviatoricStress) );
+    auto tmp = computePrincipalValDir(from_voigt_stress_6(deviatoricStress) );
     auto principalDeviatoricStress = tmp.first;
     auto principalDir = tmp.second;
 
@@ -2901,7 +2901,7 @@ ConcreteDPM2::computeDDCosThetaDDStress(const FloatArrayF< 6 > &stress) const
 
     //compute principal stresses and directions
     //auto [principalDeviatoricStress, principalDir] = computePrincipalValDir(from_voigt_stress(deviatoricStress)); // c++17
-    auto tmp = computePrincipalValDir(from_voigt_stress(deviatoricStress) );
+    auto tmp = computePrincipalValDir(from_voigt_stress_6(deviatoricStress) );
     auto principalDeviatoricStress = tmp.first;
     auto principalDir = tmp.second;
 

--- a/src/sm/Materials/ConcreteMaterials/frcfcm.C
+++ b/src/sm/Materials/ConcreteMaterials/frcfcm.C
@@ -261,7 +261,7 @@ FRCFCM :: computeCrackFibreAngle(GaussPoint *gp, int index) const
 
     double theta = 0.;
 
-    for ( int i = 1; i <= min( status->giveCrackDirs().giveNumberOfRows(), this->orientationVector.giveSize() ); i++ ) {
+    for ( int i = 1; i <= min( (int)status->giveCrackDirs().giveNumberOfRows(), (int)this->orientationVector.giveSize() ); i++ ) {
         theta += status->giveCrackDirs().at(i, index) * this->orientationVector.at(i);
     }
 

--- a/src/sm/Materials/ConcreteMaterials/idmgrad.C
+++ b/src/sm/Materials/ConcreteMaterials/idmgrad.C
@@ -155,7 +155,7 @@ IsotropicGradientDamageMaterial :: giveGradientDamageStiffnessMatrix_ud(FloatMat
         } else {
             stress.times(0.);
         }
-        answer.initFromVector(stress, false);
+        answer=FloatMatrix::fromArray(stress, false);
         if ( tempDamage > status->giveDamage() ) {
             answer.times(-gPrime);
             /*
@@ -178,7 +178,7 @@ IsotropicGradientDamageMaterial :: giveGradientDamageStiffnessMatrix_ud(FloatMat
         }
         // zero block for now
     } else {
-        answer.initFromVector(stress, false);
+        answer=FloatMatrix::fromArray(stress, false);
         answer.times(0);
     }
 }
@@ -193,7 +193,7 @@ IsotropicGradientDamageMaterial :: giveGradientDamageStiffnessMatrix_du(FloatMat
     FloatArray totalStrain = status->giveTempStrainVector();
     StructuralMaterial :: giveReducedSymVectorForm( reducedStrain, totalStrain, gp->giveMaterialMode() );
     this->computeEta(eta, reducedStrain, gp, tStep);
-    answer.initFromVector(eta, false);
+    answer=FloatMatrix::fromArray(eta, false);
     if ( mode == TangentStiffness ) {
         double tempDamage = status->giveTempDamage();
         if ( tempDamage > status->giveDamage() ) {
@@ -336,7 +336,7 @@ IsotropicGradientDamageMaterial :: giveGradientDamageStiffnessMatrix_dd_BN(Float
             double denom = sqrt( ( 1. - exp(-di_eta) ) * ( ( 1. - di_rho ) * exp(-di_eta * damage) + di_rho - exp(-di_eta) ) );
             double gPrime = this->damageFunctionPrime(tempKappa, gp);
             double factor = iL * internalLength * nom / denom * gPrime;
-            answer.initFromVector(status->giveTempNonlocalDamageDrivingVariableGrad(), false);
+            answer=FloatMatrix::fromArray(status->giveTempNonlocalDamageDrivingVariableGrad(), false);
             if ( tempKappa > status->giveKappa() ) {
                 answer.times(factor);
             } else {
@@ -349,7 +349,7 @@ IsotropicGradientDamageMaterial :: giveGradientDamageStiffnessMatrix_dd_BN(Float
             double iBPrime = this->computeEikonalInternalLength_bPrime(gp);
             double gPrime = this->damageFunctionPrime(tempKappa, gp);
 
-            answer.initFromVector(status->giveTempNonlocalDamageDrivingVariableGrad(), false);
+            answer=FloatMatrix::fromArray(status->giveTempNonlocalDamageDrivingVariableGrad(), false);
 
             if ( tempKappa > status->giveKappa() ) {
                 answer.times(iBPrime * gPrime);

--- a/src/sm/Materials/InterfaceMaterials/intmatbilinczfagerstrom.C
+++ b/src/sm/Materials/InterfaceMaterials/intmatbilinczfagerstrom.C
@@ -188,7 +188,7 @@ IntMatBilinearCZFagerstrom :: giveFirstPKTraction_3d(const FloatArrayF<3> &d, co
               dAlpha = 1. - oldDamage;
             }
 
-            auto Iep = Smati({0,1,2},{0,1,2});
+            FloatMatrixF<3,3> Iep = Smati({0,1,2},{0,1,2});
             status->letTempIepBe(Iep);
 
             FloatArrayF<3> alpha_v = {

--- a/src/sm/Materials/InterfaceMaterials/intmatbilinczfagerstromrate.C
+++ b/src/sm/Materials/InterfaceMaterials/intmatbilinczfagerstromrate.C
@@ -256,7 +256,7 @@ IntMatBilinearCZFagerstromRate :: giveFirstPKTraction_3d(const FloatArrayF<3> &d
                 dAlpha = 1. - oldDamage;
             }
 
-            auto Iep = Smati({0,1,2},{0,1,2});
+            FloatMatrixF<3,3> Iep = Smati({0,1,2},{0,1,2});
             status->letTempIepBe(Iep);
 
             FloatArrayF<3> alpha_v {

--- a/src/sm/Materials/InterfaceMaterials/structuralinterfacematerial.C
+++ b/src/sm/Materials/InterfaceMaterials/structuralinterfacematerial.C
@@ -58,7 +58,7 @@ StructuralInterfaceMaterial :: giveIPValue(FloatArray &answer, GaussPoint *gp, I
         answer = status->giveFirstPKTraction();
         return 1;
     } else if ( type == IST_DeformationGradientTensor ) {
-        answer = to_voigt_form( status->giveF() );
+        answer = to_voigt_form_33( status->giveF() );
         return 1;
     } else if ( type == IST_InterfaceNormal ) {
         answer = status->giveNormal();

--- a/src/sm/Materials/Obsolete/perfectlyplasticmaterial.C
+++ b/src/sm/Materials/Obsolete/perfectlyplasticmaterial.C
@@ -550,13 +550,13 @@ PerfectlyPlasticMaterial :: computePlasticStiffnessAt(FloatMatrix &answer,
     yeldStressGrad = this->GiveYCStressGradient(gp, currentStressVector,
                                                 currentPlasticStrainVector);
     crossSection->imposeStressConstrainsOnGradient(gp, yeldStressGrad);
-    yeldStressGradMat = new FloatMatrix(*yeldStressGrad, 1); // transpose
+    yeldStressGradMat = new FloatMatrix(FloatMatrix::fromArray(*yeldStressGrad, 1)); // transpose
 
     loadingStressGrad = this->GiveLCStressGradient(gp, currentStressVector,
                                                    currentPlasticStrainVector);
 
     crossSection->imposeStrainConstrainsOnGradient(gp, loadingStressGrad);
-    loadingStressGradMat = new FloatMatrix(*yeldStressGrad);
+    loadingStressGradMat = new FloatMatrix(FloatMatrix::fromArray(*yeldStressGrad));
 
     help.beProductOf(de, * loadingStressGrad);
     delete loadingStressGrad;

--- a/src/sm/Materials/Obsolete/plasticmaterial.C
+++ b/src/sm/Materials/Obsolete/plasticmaterial.C
@@ -157,7 +157,7 @@ PlasticMaterial :: giveRealStressVector(FloatArray &answer,
                                       fullStressVector, * fullStressSpaceHardeningVars);
 
         // obtain increment to consistency parameter
-        helpMtrx.initFromVector(* gradientVectorR, 1);
+        helpMtrx=FloatMatrix::fromArray(* gradientVectorR, 1);
         helpMtrx2.beProductOf(helpMtrx, consistentModuli);
         helpVec.beProductOf(helpMtrx2, * gradientVectorR);
         helpVal1 = helpVec.at(1);

--- a/src/sm/Materials/RheoChainMaterials/kelvinChSolM.C
+++ b/src/sm/Materials/RheoChainMaterials/kelvinChSolM.C
@@ -61,7 +61,9 @@ KelvinChainSolidMaterial :: giveEModulus(GaussPoint *gp, TimeStep *tStep) const
         OOFEM_ERROR("Attempted to evaluate E modulus at time lower than casting time");
     }
     double sum = 0.0;
-#pragma omp critical (KelvinChainSolidMaterial_EModulus)
+    #ifdef _OPENMP
+        #pragma omp critical (KelvinChainSolidMaterial_EModulus)
+    #endif
     {
         if ( this->EparVal.isEmpty() ) {
             this->updateEparModuli(0., gp, tStep); // stiffnesses are time independent (evaluated at time t = 0.)

--- a/src/sm/Materials/RheoChainMaterials/maxwellChM.C
+++ b/src/sm/Materials/RheoChainMaterials/maxwellChM.C
@@ -121,7 +121,9 @@ MaxwellChainMaterial :: giveEModulus(GaussPoint *gp, TimeStep *tStep) const
     }
 
     double tPrime = this->relMatAge - this->castingTime + ( tStep->giveTargetTime() - 0.5 * tStep->giveTimeIncrement() ) / timeFactor;
-#pragma omp critical (MaxwellChainMaterial_EModulus)
+    #ifdef _OPENMP
+        #pragma omp critical (MaxwellChainMaterial_EModulus)
+    #endif
     {
         this->updateEparModuli(tPrime, gp, tStep);
 

--- a/src/sm/Materials/RheoChainMaterials/mps.C
+++ b/src/sm/Materials/RheoChainMaterials/mps.C
@@ -748,7 +748,9 @@ MPSMaterial::giveEModulus(GaussPoint *gp, TimeStep *tStep) const
     if ( status->giveStoredEmodulusFlag() ) {
         Emodulus = status->giveStoredEmodulus();
     } else {
-#pragma omp critical (MPS_Emodulus)
+        #ifdef _OPENMP
+            #pragma omp critical (MPS_Emodulus)
+        #endif
         { // critical section as EparVal is a class variable; if the receiver is slave model (e.g. ConcreteFCMViscoElastic) 
           // it can be shared by several master models with different parameters
             if ( EparVal.giveSize() == 0 ) {

--- a/src/sm/Materials/abaqususermaterial.C
+++ b/src/sm/Materials/abaqususermaterial.C
@@ -409,9 +409,9 @@ AbaqusUserMaterial::giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, Gauss
     FloatArrayF< 9 >abq_stress; // PK1 or cauchy
 
     // compute Green-Lagrange strain
-    auto F = from_voigt_form(vF);
+    auto F = from_voigt_form_9(vF);
     auto E = 0.5 * ( Tdot(F, F) - eye< 3 >() );
-    auto strain = to_voigt_strain(E);
+    auto strain = to_voigt_strain_33(E);
 
     auto strainIncrement = strain - FloatArrayF< 6 >( ms->giveStrainVector() );
     FloatArray state = ms->giveStateVector();
@@ -465,12 +465,12 @@ AbaqusUserMaterial::giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, Gauss
 
     /* Array containing the deformation gradient at the beginning of the increment. See the discussion
      * regarding the availability of the deformation gradient for various element types. */
-    auto dfgrd0 = from_voigt_form(ms->giveFVector() );
+    auto dfgrd0 = from_voigt_form_9(ms->giveFVector() );
     /* Array containing the deformation gradient at the end of the increment. The components of this array
      * are set to zero if nonlinear geometric effects are not included in the step definition associated with
      * this increment. See the discussion regarding the availability of the deformation gradient for various
      * element types. */
-    auto dfgrd1 = from_voigt_form(vF);
+    auto dfgrd1 = from_voigt_form_9(vF);
 
     int noel = gp->giveElement()->giveNumber(); // Element number.
     int npt = 0; // Integration point number.
@@ -534,11 +534,11 @@ AbaqusUserMaterial::giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, Gauss
 
     if ( mStressInterpretation == 0 ) {
         auto stress = abq_stress [ abq2oo9 ];
-        auto P = from_voigt_form(stress);
-        auto vP = to_voigt_form(P);
+        auto P = from_voigt_form_9(stress);
+        auto vP = to_voigt_form_33(P);
 
         auto cauchyStress = dotT(P, F) * ( 1. / det(F) );
-        auto vCauchyStress = to_voigt_stress(cauchyStress);
+        auto vCauchyStress = to_voigt_stress_33(cauchyStress);
 
         ms->letTempStrainVectorBe(strain);
         ms->letTempStressVectorBe(vCauchyStress);
@@ -550,15 +550,15 @@ AbaqusUserMaterial::giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, Gauss
         return vP;
     } else {
         auto vsigma = abq_stress [ abq2oo6 ];
-        auto sigma = from_voigt_stress(vsigma);
+        auto sigma = from_voigt_stress_6(vsigma);
 
         auto P = dot(F, sigma);
-        auto vP = to_voigt_form(P);
+        auto vP = to_voigt_form_33(P);
 
         // Convert from sigma to S
         auto F_inv = inv(F);
         auto S = dot(F_inv, P);
-        auto vS = to_voigt_stress(S);
+        auto vS = to_voigt_stress_33(S);
 
         // @todo Should convert from dsigmadE to dSdE here
         // L2=detF*matmul( matmul ( inv(op_a_V9(F,F), cm-op_a_V9(ident,Tau)-op_b_V9(Tau,ident) ), inv(op_a_V9(Ft,Ft)))

--- a/src/sm/Materials/anisolinearelasticmaterial.C
+++ b/src/sm/Materials/anisolinearelasticmaterial.C
@@ -84,7 +84,7 @@ AnisotropicLinearElasticMaterial :: giveInputRecord(DynamicInputRecord &input)
     }
     input.setField(stiffness, _IFT_AnisotropicLinearElasticMaterial_stiff);
 
-    input.setField(alpha, _IFT_AnisotropicLinearElasticMaterial_talpha);
+    input.setField(FloatArray(alpha), _IFT_AnisotropicLinearElasticMaterial_talpha);
 }
 
 } // end namespace oofem

--- a/src/sm/Materials/lsmastermat.C
+++ b/src/sm/Materials/lsmastermat.C
@@ -77,7 +77,7 @@ LargeStrainMasterMaterial :: giveFirstPKStressVector_3d(const FloatArrayF<9> &vF
     auto sMat = static_cast< StructuralMaterial * >( domain->giveMaterial(slaveMat) );
 
     //store of deformation gradient into 3x3 matrix
-    auto F = from_voigt_form(vF);
+    auto F = from_voigt_form_9(vF);
     //compute right Cauchy-Green tensor(C), its eigenvalues and eigenvectors
     auto C = Tdot(F, F);
     // compute eigen values and eigen vectors of C
@@ -107,7 +107,7 @@ LargeStrainMasterMaterial :: giveFirstPKStressVector_3d(const FloatArrayF<9> &vF
         }
     }
 
-    auto SethHillStrainVector = to_voigt_strain(SethHillStrain);
+    auto SethHillStrainVector = to_voigt_strain_33(SethHillStrain);
     auto stressVector = sMat->giveRealStressVector_3d(SethHillStrainVector, gp, tStep);
 
     auto T = this->constructTransformationMatrix(eVecs);
@@ -133,8 +133,8 @@ LargeStrainMasterMaterial :: giveFirstPKStressVector_3d(const FloatArrayF<9> &vF
     stressVector.at(6) *= 0.5;
     auto secondPK = dot(P, FloatArrayF<6>(stressVector));
 
-    auto firstPK = dot(F, from_voigt_stress(secondPK)); // P = F*S
-    auto firstPKv = to_voigt_form(firstPK);
+    auto firstPK = dot(F, from_voigt_stress_6(secondPK)); // P = F*S
+    auto firstPKv = to_voigt_form_33(firstPK);
     auto TL = Tdot(T, dot(L2, T));
     status->setPmatrix(P);
     status->setTLmatrix(TL);

--- a/src/sm/Materials/rankinematgrad.C
+++ b/src/sm/Materials/rankinematgrad.C
@@ -471,7 +471,7 @@ RankineMatGrad :: giveGradientDamageStiffnessMatrix_dd_BN(FloatMatrix &answer, M
         {
             RankineMatGradStatus *status = static_cast< RankineMatGradStatus * >( this->giveStatus(gp) );
             FloatArray GradP = status->giveTempNonlocalDamageDrivingVariableGrad();
-            answer = GradP;
+            answer = FloatMatrix::fromArray(GradP);
             double iBPrime = this->computeEikonalInternalLength_bPrime(gp);
             double tempKappa = status->giveTempCumulativePlasticStrain();
             double gPrime = this->computeDamageParamPrime(tempKappa);

--- a/src/sm/Materials/structuralmaterial.C
+++ b/src/sm/Materials/structuralmaterial.C
@@ -62,6 +62,7 @@ std::array< std::array< int, 3 >, 3 >StructuralMaterial::svIndex = {{
 }};
 
 
+
 StructuralMaterial::StructuralMaterial(int n, Domain *d) : Material(n, d) { }
 
 
@@ -716,7 +717,7 @@ StructuralMaterial::givePlaneStressStiffnessMatrix_dPdF(MatResponseMode mode,
 {
     auto m3d = this->give3dMaterialStiffnessMatrix_dPdF(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 1, 5, 8 }, { 0, 1, 5, 8 }) );
+    return inv( FloatMatrixF<4,4>(c3d({ 0, 1, 5, 8 }, { 0, 1, 5, 8 })));
 }
 
 
@@ -1033,7 +1034,7 @@ StructuralMaterial::givePlaneStressStiffMtrx(MatResponseMode mode,
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 1, 5 }, { 0, 1, 5 }) );
+    return inv(FloatMatrixF<3,3>(c3d({ 0, 1, 5 }, { 0, 1, 5 })));
 }
 
 FloatMatrixF< 4, 4 >
@@ -1065,7 +1066,7 @@ StructuralMaterial::give2dBeamLayerStiffMtrx(MatResponseMode mode,
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 4 }, { 0, 4 }) );
+    return inv(FloatMatrixF<2,2>(c3d({ 0, 4 }, { 0, 4 })));
 }
 
 
@@ -1076,7 +1077,7 @@ StructuralMaterial::givePlateLayerStiffMtrx(MatResponseMode mode,
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 1, 3, 4, 5 }, { 0, 1, 3, 4, 5 }) );
+    return inv(FloatMatrixF<5,5>(c3d({ 0, 1, 3, 4, 5 }, { 0, 1, 3, 4, 5 })));
 }
 
 FloatMatrixF< 3, 3 >
@@ -1086,7 +1087,7 @@ StructuralMaterial::giveFiberStiffMtrx(MatResponseMode mode,
 {
     auto m3d = this->give3dMaterialStiffnessMatrix(mode, gp, tStep);
     auto c3d = inv(m3d);
-    return inv(c3d({ 0, 4, 5 }, { 0, 4, 5 }) );
+    return inv(FloatMatrixF<3,3>(c3d({ 0, 4, 5 }, { 0, 4, 5 })));
 }
 
 

--- a/src/sm/Materials/structuralmaterial.C
+++ b/src/sm/Materials/structuralmaterial.C
@@ -333,16 +333,16 @@ StructuralMaterial::giveFirstPKStressVector_3d(const FloatArrayF< 9 > &vF, Gauss
     // 2) Treat stress as second Piola-Kirchhoff stress and convert to first Piola-Kirchhoff stress.
     // 3) Set state variables F, P
 
-    auto F = from_voigt_form(vF);
+    auto F = from_voigt_form_9(vF);
     auto E = 0.5 * ( Tdot(F, F) - eye< 3 >() );
-    auto vE = to_voigt_strain(E);
+    auto vE = to_voigt_strain_33(E);
     auto vS = this->giveRealStressVector_3d(vE, gp, tStep);
 
     // Compute first PK stress from second PK stress
     auto status = static_cast< StructuralMaterialStatus * >( this->giveStatus(gp) );
-    auto S = from_voigt_stress(vS);
+    auto S = from_voigt_stress_6(vS);
     auto P = dot(F, S);
-    auto vP = to_voigt_form(P);
+    auto vP = to_voigt_form_33(P);
     status->letTempPVectorBe(vP);
     status->letTempFVectorBe(vF);
 

--- a/src/sm/prescribeddispslipmultiple.C
+++ b/src/sm/prescribeddispslipmultiple.C
@@ -94,7 +94,7 @@ void PrescribedDispSlipMultiple::setSlipField( const FloatArray &t )
 
 void PrescribedDispSlipMultiple::setDispGradient( const FloatArray &t )
 {
-    this->slipGradient = t;
+    this->slipGradient = FloatMatrix::fromArray(t);
     for ( int i : this->bcs ) {
         auto bc = dynamic_cast<PrescribedDispSlipHomogenization*>(this->giveDomain()->giveBc(i));
         bc->setDispGradient(t);
@@ -104,7 +104,7 @@ void PrescribedDispSlipMultiple::setDispGradient( const FloatArray &t )
 
 void PrescribedDispSlipMultiple::setSlipGradient( const FloatArray &t )
 {
-    this->slipGradient = t;
+    this->slipGradient = FloatMatrix::fromArray(t);
     for ( int i : this->bcs ) {
         auto bc = dynamic_cast<PrescribedDispSlipHomogenization*>(this->giveDomain()->giveBc(i));
         bc->setSlipGradient(t);

--- a/src/sm/refinedmesh.C
+++ b/src/sm/refinedmesh.C
@@ -1974,6 +1974,9 @@ RefinedMesh :: refineMeshGlobally(Domain *d, int level, std :: vector< RefinedEl
 
             p = ( level + 2 ) * ( level + 1 );
             mesh_face = mesh_fc [ 0 ];
+            #pragma GCC diagnostic push
+            // swap[0] possibly uninitialized
+            #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             for ( k = 0; k < 3; k++ ) {
                 if ( mesh_face->node [ k ] == fe_tetra->node [ j ] ) {
                     if ( swap [ 0 ] == 1 ) {
@@ -1987,6 +1990,7 @@ RefinedMesh :: refineMeshGlobally(Domain *d, int level, std :: vector< RefinedEl
                     break;
                 }
             }
+            #pragma GCC diagnostic pop
 
             for ( m = 0; m < level + 2; m++ ) {
                 tmp_array [ j ] [ pos++ ] = mesh_face->fine_id [ kk ] [ p++ ];
@@ -2329,6 +2333,9 @@ RefinedMesh :: refineMeshGlobally(Domain *d, int level, std :: vector< RefinedEl
 
             p = ( level + 2 ) * ( level + 1 );
             mesh_quad = mesh_qd [ 0 ];
+            #pragma GCC diagnostic push
+            // swap[0] possibly uninitialized
+            #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             for ( k = 0; k < 4; k++ ) {
                 if ( mesh_quad->node [ k ] == fe_hexa->node [ j ] ) {
                     if ( swap [ 0 ] == 1 ) {
@@ -2342,6 +2349,7 @@ RefinedMesh :: refineMeshGlobally(Domain *d, int level, std :: vector< RefinedEl
                     break;
                 }
             }
+            #pragma GCC diagnostic pop
 
             for ( m = 0; m < level + 2; m++ ) {
                 tmp_array [ j ] [ pos++ ] = mesh_quad->fine_id [ kk ] [ p++ ];
@@ -2388,6 +2396,9 @@ RefinedMesh :: refineMeshGlobally(Domain *d, int level, std :: vector< RefinedEl
 
             p = ( level + 2 ) * ( level + 1 );
             mesh_quad = mesh_qd [ 5 ];
+            #pragma GCC diagnostic push
+            // swap[5] possibly uninitialized
+            #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
             for ( k = 0; k < 4; k++ ) {
                 if ( mesh_quad->node [ k ] == fe_hexa->node [ j + 4 ] ) {
                     if ( swap [ 5 ] == 0 ) {
@@ -2401,6 +2412,7 @@ RefinedMesh :: refineMeshGlobally(Domain *d, int level, std :: vector< RefinedEl
                     break;
                 }
             }
+            #pragma GCC diagnostic pop
 
             for ( m = 0; m < level + 2; m++ ) {
                 tmp_array [ j + 4 ] [ pos++ ] = mesh_quad->fine_id [ kk ] [ p++ ];

--- a/src/sm/stressstrainbasevector.C
+++ b/src/sm/stressstrainbasevector.C
@@ -62,12 +62,8 @@ StressStrainBaseVector &
 StressStrainBaseVector :: operator = ( const StressStrainBaseVector & src )
 {
     if ( this != & src ) { // beware of s=s;
-        #ifdef _USE_EIGEN
-            this->resizeLike(src);
-            for(Eigen::Index i=0; i<this->size(); i++) (*this)[i]=src[i];
-        #else
-            this->values = src.values;
-        #endif
+        this->resize(src.size()); // FIXME: useless zero-assignment
+        for(Index i=0; i<this->size(); i++) (*this)[i]=src[i];
     }
 
     this->mode = src.mode;

--- a/src/tm/BoundaryCondition/transportgradientdirichlet.C
+++ b/src/tm/BoundaryCondition/transportgradientdirichlet.C
@@ -127,7 +127,7 @@ double TransportGradientDirichlet :: give(Dof *dof, ValueModeType mode, double t
     }
 
     // Reminder: u_i = g_i . (x_i - xc_i + xi_i)
-    auto dx = coords - this->mCenterCoord;
+    FloatArray dx = coords - this->mCenterCoord;
     // Add "xi" if it is defined. Classical Dirichlet b.c. is retained if this isn't defined (or set to zero).
     if ( !xis.empty() ) {
         dx.add(xis[dof->giveDofManager()->giveNumber()]);
@@ -591,7 +591,7 @@ void TransportGradientDirichlet :: computeXi()
             for ( int i = 1; i <= bNodes.giveSize(); ++i ) {
                 int enode = bNodes.at(i);
                 Node *n = e->giveNode(enode);
-                auto x = n->giveCoordinates() + this->xis[n->giveNumber()];
+                FloatArray x = n->giveCoordinates() + this->xis[n->giveNumber()];
                 cvec.at(i, 1) = x.at(1);
                 cvec.at(i, 2) = x.at(2);
                 cvec.at(i, 3) = x.at(3);

--- a/src/tm/BoundaryCondition/transportgradientperiodic.C
+++ b/src/tm/BoundaryCondition/transportgradientperiodic.C
@@ -321,7 +321,7 @@ void TransportGradientPeriodic :: computeDofTransformation(ActiveDof *dof, Float
     const auto &coords = dof->giveDofManager()->giveCoordinates();
     const auto &masterCoords = master->giveCoordinates();
 
-    auto dx = coords - masterCoords;
+    FloatArray dx = coords - masterCoords;
 
     masterContribs.resize(dx.giveSize() + 1);
 

--- a/src/tm/Materials/rvestokesflow.C
+++ b/src/tm/Materials/rvestokesflow.C
@@ -207,7 +207,11 @@ RVEStokesFlow :: computeTangent3D(MatResponseMode mode, GaussPoint *gp, TimeStep
         FloatMatrix answer;
         status->giveRVE()->computeTangent(answer, tStep);
         answer.resizeWithData(3, 3);
+        #pragma GCC diagnostic push
+        // answer is possible uninitialized
+        #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         status->letTempTangentMatrixBe(answer);
+        #pragma GCC diagnostic pop
         status->oldTangent = false;
         return answer;
     } else {

--- a/src/tm/transportcrosssection.h
+++ b/src/tm/transportcrosssection.h
@@ -56,8 +56,12 @@ public:
      */
     TransportCrossSection(int n, Domain * d) : CrossSection(n, d) { }
 
+    #pragma GCC diagnostic push
+    /// hides virtual oofem::Material* CrossSection::giveMaterial(oofem::IntegrationPoint*) const
+    #pragma GCC diagnostic ignored "-Woverloaded-virtual"
     /// @todo Temporary function that hands out the material. Must be removed for future layered support, but input files will still look the same.
     virtual TransportMaterial *giveMaterial() const = 0;
+    #pragma GCC diagnostic pop
 };
 } // end namespace oofem
 #endif // transportcrosssection_h


### PR DESCRIPTION
This changeset derives all numerical classes (FloatMatrix, FloatArray, FloatMatrixF, FloatArrayF) from Eigen base classes, without changing the API. Implementation of those classes was adjusted so that Eigen and non-Eigen variants share maximum code. Numerical methods (such as dot products etc) still use the original implementations. All tests are passing.

Compilation of the entire code is about 30% up, runtime (for tests) is same-same, binary size is a few percent smaller for Eigen.