### PR TITLE
cleanup progressbar at crash

### DIFF
--- a/src/core/progressbar.h
+++ b/src/core/progressbar.h
@@ -100,6 +100,7 @@ private:
     bool need_resize = true;
 
     static void handle_resize(int) ;
+    static void handle_crash(int) ;
 
     void get_size_unix(int& rows, int& cols) ;
 


### PR DESCRIPTION
(otherwise it stays in the terminal forever)

Normally one should query $TERM  and use termcap to get terminal capabilities, using escape codes will likely break for some systems... There are battle-tested progress bar implementations like https://github.com/p-ranav/indicators , also a single-header version, just sayin'.