### PR TITLE
Size mismatches

### DIFF
--- a/src/core/floatarray.C
+++ b/src/core/floatarray.C
@@ -161,7 +161,11 @@ void FloatArray :: beScaled(double s, const FloatArray &b){ *this=b*s; }
 void FloatArray :: add(const FloatArray &b){ if(b.isEmpty()) return; if(this->isEmpty()){ *this=b; return; } *this+=b; }
 void FloatArray :: add(double offset){ this->array()+=offset; }
 void FloatArray :: add(double factor, const FloatArray &b) { if(this->isEmpty()){ *this=factor*b;  return; }  *this+=factor*b; }
-void FloatArray :: plusProduct(const FloatMatrix &b, const FloatArray &s, double dV){ if(this->isEmpty()){ *this=b.transpose()*s*dV;  return; } *this+=b.transpose()*s*dV; }
+void FloatArray :: plusProduct(const FloatMatrix &b, const FloatArray &s, double dV){
+    // std::cerr<<"plusProduct: this["<<this->size()<<"], b["<<b.rows()<<"r,"<<b.cols()<<"c], s["<<s.size()<<"]"<<std::endl;
+    // the s.head(b.rows()) clips s in case it is longer, some (broken) code relies on this
+    if(this->isEmpty()){ *this=b.transpose()*s.head(b.rows())*dV;  return; } *this+=b.transpose()*s.head(b.rows())*dV;
+}
 void FloatArray :: subtract(const FloatArray &src){ if(src.isEmpty()) return; if(this->isEmpty()){ *this=-src; return; } *this-=src; }
 void FloatArray :: beMaxOf(const FloatArray &a, const FloatArray &b){ if(a.isEmpty()){ *this=b; return; } if(b.isEmpty()){ *this=a; return; } *this=a.array().max(b.array()).matrix(); }
 void FloatArray :: beMinOf(const FloatArray &a, const FloatArray &b){  if(a.isEmpty()){ *this=b; return; } if(b.isEmpty()){ *this=a; return; } *this=a.array().min(b.array()).matrix(); }
@@ -300,11 +304,12 @@ void FloatArray :: plusProduct(const FloatMatrix &b, const FloatArray &s, double
     if ( this->isEmpty() ) {
         this->resize( nColumns );
     }
-
 #  ifndef NDEBUG
     if ( this->giveSize() != b.giveNumberOfColumns() ) {
         OOFEM_ERROR( "dimension mismatch in a[%d] and b[%d, *]", this->giveSize(), b.giveNumberOfColumns() );
     }
+    // this should be checked, but some code actually passes s which is longer
+    // if (b.rows() != s.size()) OOFEM_ERROR("dimension mismatch in b[%dr,*c] and s[%d]",(int)b.rows(),(int)s.size());
 #  endif
 
 #ifdef __LAPACK_MODULE

--- a/src/core/progressbar.h
+++ b/src/core/progressbar.h
@@ -100,6 +100,7 @@ private:
     bool need_resize = true;
 
     static void handle_resize(int) ;
+    static void handle_crash(int) ;
 
     void get_size_unix(int& rows, int& cols) ;
 


### PR DESCRIPTION
I am not sure about this PR, since it fixes the effect instead of fixing the source:

There is some code which relies on plusProduct ignoring extra elements of s (has 6, but only 3 are used), which would crash with Eigen when sizes are cheked. If you uncommend the check in non-eigen plusProduct, you'd see he crash as well. I would say the caller (oofem::StructuralElement::giveInternalForcesVecto) should be fixed: the `s` vector has size `6`, but only 3 elements are used.

```c++
#6  0x00007ffff783b517 in __assert_fail (
    assertion=0x55555635a1e0 "lhs.cols() == rhs.rows() && \"invalid matrix product\" && \"if you wanted a coeff-wise or a dot product use the respective explicit functions\"", file=0x55555635a1b0 "/usr/include/eigen3/Eigen/src/Core/Product.h", line=96, 
    function=0x55555635a090 "Eigen::Product<Lhs, Rhs, Option>::Product(const Lhs&, const Rhs&) [with _Lhs = Eigen::Transpose<const Eigen::Matrix<double, -1, -1> >; _Rhs = Eigen::Matrix<double, -1, 1>; int Option = 0; Lhs = Eigen:"...) at ./assert/assert.c:105
#7  0x0000555555975b01 in Eigen::Product<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> const>, Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0>::Product (
    this=0x7fffffffd050, lhs=..., rhs=...) at /usr/include/eigen3/Eigen/src/Core/Product.h:96
#8  0x0000555555973d36 in Eigen::MatrixBase<Eigen::Transpose<Eigen::Matrix<double, -1, -1, 0, -1, -1> const> >::operator*<Eigen::Matrix<double, -1, 1, 0, -1, 1> > (
    this=0x7fffffffd0b8, other=...) at /usr/include/eigen3/Eigen/src/Core/GeneralProduct.h:424
#9  0x000055555596fe6c in oofem::FloatArray::plusProduct (this=0x7fffffffd430, b=..., s=..., dV=0.10000000000000001) at /home/eudoxos/oofem/src/core/floatarray.C:164
#10 0x0000555555e9a172 in oofem::StructuralElement::giveInternalForcesVector (this=0x555556acbb80, answer=..., tStep=0x555556ac4660, useUpdatedGpRecord=1)
    at /home/eudoxos/oofem/src/sm/Elements/structuralelement.C:791
#11 0x0000555555e9ac8e in oofem::StructuralElement::giveCharacteristicVector (this=0x555556acbb80, answer=..., mtrx=oofem::LastEquilibratedInternalForcesVector, 
    mode=oofem::VM_Total, tStep=0x555556ac4660) at /home/eudoxos/oofem/src/sm/Elements/structuralelement.C:930
#12 0x0000555555db3905 in oofem::LastEquilibratedInternalForceAssembler::vectorFromElement (this=0x7fffffffd580, vec=..., element=..., tStep=0x555556ac4660, 
    mode=oofem::VM_Total) at /home/eudoxos/oofem/src/sm/EngineeringModels/structengngmodel.C:57
#13 0x00005555559fecfa in oofem::EngngModel::assembleVectorFromElements (this=0x555556ac9b80, answer=..., tStep=0x555556ac4660, va=..., mode=oofem::VM_Total, s=..., 
    domain=0x555556ac4900, eNorms=0x0) at /home/eudoxos/oofem/src/core/engngm.C:1405
#14 0x00005555559fd715 in oofem::EngngModel::assembleVector (this=0x555556ac9b80, answer=..., tStep=0x555556ac4660, va=..., mode=oofem::VM_Total, s=..., 
    domain=0x555556ac4900, eNorms=0x0) at /home/eudoxos/oofem/src/core/engngm.C:1137
#15 0x0000555555db4538 in oofem::StructuralEngngModel::computeReaction (this=0x555556ac9b80, answer=..., tStep=0x555556ac4660, di=1)
    at /home/eudoxos/oofem/src/sm/EngineeringModels/structengngmodel.C:191
#16 0x0000555555db3eef in oofem::StructuralEngngModel::printReactionForces (this=0x555556ac9b80, tStep=0x555556ac4660, di=1, out=0x555556ab2750)
    at /home/eudoxos/oofem/src/sm/EngineeringModels/structengngmodel.C:124
```

One more similar case is the new `plus_Nt_a_otimes_b_B` in contacts, which also have incompatible dimensions (and crash with Eigen when checking sizes), but I am not fixing this one.

```c++
#6  0x00007ffff783b517 in __assert_fail (
    assertion=0x55555635b228 "lhs.cols() == rhs.rows() && \"invalid matrix product\" && \"if you wanted a coeff-wise or a dot product use the respective explicit functions\"", file=0x55555635b1f8 "/usr/include/eigen3/Eigen/src/Core/Product.h", line=96, 
    function=0x55555635be88 "Eigen::Product<Lhs, Rhs, Option>::Product(const Lhs&, const Rhs&) [with _Lhs = Eigen::Matrix<double, -1, -1>; _Rhs = Eigen::Matrix<double, -1, 1>; int Option = 0; Lhs = Eigen::Matrix<double, -1, -1>; "...) at ./assert/assert.c:105
#7  0x000055555597716a in Eigen::Product<Eigen::Matrix<double, -1, -1, 0, -1, -1>, Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0>::Product (this=0x7fffffffcda0, lhs=..., 
    rhs=...) at /usr/include/eigen3/Eigen/src/Core/Product.h:96
#8  0x0000555555974d56 in Eigen::MatrixBase<Eigen::Matrix<double, -1, -1, 0, -1, -1> >::operator*<Eigen::Matrix<double, -1, 1, 0, -1, 1> > (this=0x7fffffffd080, 
    other=...) at /usr/include/eigen3/Eigen/src/Core/GeneralProduct.h:424
#9  0x0000555555996f78 in oofem::FloatMatrix::plus_Nt_a_otimes_b_B (this=0x7fffffffd310, N=..., a=..., b=..., B=..., dV=100000000)
    at /home/eudoxos/oofem/src/core/floatmatrix.C:316
#10 0x0000555555e89561 in oofem::StructuralPenaltyContactBoundaryCondition::computeTangentFromContact (this=0x555556ad1930, answer=..., contactPair=0x555556ad3e10, 
    tStep=0x555556ac75a0) at /home/eudoxos/oofem/src/sm/Contact/structuralpenaltycontactbc.C:82
#11 0x0000555555b634b3 in oofem::ContactBoundaryCondition::assemble (this=0x555556ad1930, answer=..., tStep=0x555556ac75a0, type=oofem::TangentStiffnessMatrix, 
    r_s=..., c_s=..., scale=1, lock=0x0) at /home/eudoxos/oofem/src/core/Contact/contactbc.C:78
#12 0x0000555555777c92 in oofem::TangentAssembler::assembleFromActiveBC (this=0x7fffffffd620, k=..., bc=..., tStep=0x555556ac75a0, s_r=..., s_c=..., lock=0x0)
    at /home/eudoxos/oofem/src/core/assemblercallback.C:277
#13 0x00005555559fcd86 in oofem::EngngModel::assemble (this=0x555556acd940, answer=..., tStep=0x555556ac75a0, ma=..., s=..., domain=0x555556acde30)
    at /home/eudoxos/oofem/src/core/engngm.C:957
#14 0x0000555555db8008 in oofem::StaticStructural::updateMatrix (this=0x555556acd940, mat=..., tStep=0x555556ac75a0, d=0x555556acde30)
    at /home/eudoxos/oofem/src/sm/EngineeringModels/staticstructural.C:419
#15 0x0000555555db6f32 in oofem::StaticStructural::solveYourselfAt (this=0x555556acd940, tStep=0x555556ac75a0)
    at /home/eudoxos/oofem/src/sm/EngineeringModels/staticstructural.C:279
#16 0x00005555559fb1d4 in oofem::EngngModel::solveYourself (this=0x555556acd940) at /home/eudoxos/oofem/src/core/engngm.C:629
```
