### PR TITLE
New definitions of read and write for MS compiler

### DIFF
--- a/src/core/dyncombuff.h
+++ b/src/core/dyncombuff.h
@@ -211,6 +211,10 @@ public:
     int read(char *dest, std::size_t n) override
     { return __read(dest, n, MPI_CHAR); }
 
+#ifdef _WIN32
+    int read( std::size_t *src, std::size_t n ) override { return __read( src, n, my_MPI_SIZE_T ); }
+    int write( const std::size_t *dest, std::size_t n ) override { return __write( dest, n, my_MPI_SIZE_T ); }
+#endif
 
     int iSend(int dest, int tag) override;
     int iRecv(int source, int tag, std::size_t count = 0) override;

--- a/src/core/processcomm.h
+++ b/src/core/processcomm.h
@@ -98,6 +98,11 @@ public:
     int read(char *data, std::size_t count) override { return this->recv_buff->read(data, count); }
     int read(bool &data) override { return recv_buff->read(data); }
 
+#ifdef _WIN32
+    int write( const size_t *data, std::size_t count ) override { return send_buff->write( data, count ); }
+    int read( size_t *data, std::size_t count ) override { return this->recv_buff->read( data, count ); }
+#endif
+
     /// Initializes send buffer to empty state. All packed data are lost.
     void initSendBuff() { send_buff->init(); }
     /// Initializes send buffer to empty state. All packed data are lost.

--- a/src/core/subdivision.C
+++ b/src/core/subdivision.C
@@ -3949,7 +3949,7 @@ Subdivision :: createMesh(TimeStep *tStep, int domainNumber, int domainSerNum, D
       for (int in=1; in<=(*dNew)->giveNumberOfDofManagers(); in++) {
         DynamicInputRecord ir;
         (*dNew)->giveDofManager(in)->giveInputRecord(ir);
-        OOFEM_LOG_INFO("[%d]:[%d]:%s\n", this->giveRank(), (*dNew)->giveDofManager(in)->giveGlobalNumber(), ir->giveRecordAsString().c_str());
+        OOFEM_LOG_INFO("[%d]:[%d]:%s\n", this->giveRank(), (*dNew)->giveDofManager(in)->giveGlobalNumber(), ir.giveRecordAsString().c_str());
       }
       IntArray nodes;
       for (int in=1; in<=(*dNew)->giveNumberOfElements(); in++) {
@@ -3959,8 +3959,8 @@ Subdivision :: createMesh(TimeStep *tStep, int domainNumber, int domainSerNum, D
         // translate local node numbers to globnums
         for (int ii=1; ii<=nodes.giveSize(); ii++)
           nodes.at(ii) = (*dNew)->giveNode(nodes.at(ii))->giveGlobalNumber();
-        ir->setField(nodes, "gnodes");
-        OOFEM_LOG_INFO("[%d]:[%d]:%s\n", this->giveRank(), (*dNew)->giveElement(in)->giveGlobalNumber(), ir->giveRecordAsString().c_str());
+        ir.setField(nodes, "gnodes");
+        OOFEM_LOG_INFO("[%d]:[%d]:%s\n", this->giveRank(), (*dNew)->giveElement(in)->giveGlobalNumber(), ir.giveRecordAsString().c_str());
       }
     }
     nelems = ( * dNew )->giveNumberOfElements();


### PR DESCRIPTION
New definitions of read and write for MS compiler in DynamicCommunicationBuffer and ProcessCommunicatorBuff classes added. The arrow operator changed with the dot operator on InputRecord objects in subdivision because the MS compiler was reporting an error.